### PR TITLE
Module-7:  Implement CQRS command handlers and dependency injection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,7 +125,7 @@ linters:
     #- goheader # checks is file header matches to pattern
     #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
     - interfacebloat # checks the number of methods inside an interface
-    - ireturn # accept interfaces, return concrete types
+    #- ireturn # accept interfaces, return concrete types
     - prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
     - tagalign # checks that struct tags are well aligned
     #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,22 +1,50 @@
 package main
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
 	"delivery/cmd"
+	"delivery/internal/adapters/out/postgres/courierrepo"
+	"delivery/internal/adapters/out/postgres/orderrepo"
+	"delivery/internal/pkg/errs"
 
 	"github.com/joho/godotenv"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/log"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
 )
 
 func main() {
 	configs := getConfigs()
 
+	connectionString, err := makeConnectionString(
+		configs.DBHost,
+		configs.DBPort,
+		configs.DBUser,
+		configs.DBPassword,
+		configs.DBName,
+		configs.DBSslMode)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	createDBIfNotExists(configs.DBHost,
+		configs.DBPort,
+		configs.DBUser,
+		configs.DBPassword,
+		configs.DBName,
+		configs.DBSslMode)
+	gormDB := mustGormOpen(connectionString)
+	mustAutoMigrate(gormDB)
+
 	app := cmd.NewCompositionRoot(
 		configs,
+		gormDB,
 	)
 	startWebServer(app, configs.HTTPPort)
 }
@@ -54,4 +82,118 @@ func startWebServer(_ cmd.CompositionRoot, port string) {
 	})
 
 	e.Logger.Fatal(e.Start(fmt.Sprintf("0.0.0.0:%s", port)))
+}
+
+func makeConnectionString(
+	host string,
+	port string,
+	user string,
+	password string,
+	dbName string,
+	sslMode string,
+) (string, error) {
+	if err := errors.Join(
+		func() error {
+			if host == "" {
+				return errs.NewValueIsRequiredError(host)
+			}
+			return nil
+		}(),
+		func() error {
+			if port == "" {
+				return errs.NewValueIsRequiredError(port)
+			}
+			return nil
+		}(),
+		func() error {
+			if user == "" {
+				return errs.NewValueIsRequiredError(user)
+			}
+			return nil
+		}(),
+		func() error {
+			if password == "" {
+				return errs.NewValueIsRequiredError(password)
+			}
+			return nil
+		}(),
+		func() error {
+			if dbName == "" {
+				return errs.NewValueIsRequiredError(dbName)
+			}
+			return nil
+		}(),
+		func() error {
+			if sslMode == "" {
+				return errs.NewValueIsRequiredError(sslMode)
+			}
+			return nil
+		}(),
+	); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("host=%v port=%v user=%v password=%v dbname=%v sslmode=%v",
+		host, port, user, password, dbName, sslMode,
+	), nil
+}
+
+func createDBIfNotExists(
+	host string,
+	port string,
+	user string,
+	password string,
+	dbName string,
+	sslMode string,
+) {
+	dsn, err := makeConnectionString(host, port, user, password, "postgres", sslMode)
+	if err != nil {
+		log.Fatalf("Ошибка подключения к PostgreSQL: %v", err)
+	}
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		log.Fatalf("Ошибка подключения к PostgreSQL: %v", err)
+	}
+
+	defer func() {
+		if err = db.Close(); err != nil {
+			log.Printf("ошибка при закрытии db: %v", err)
+		}
+	}()
+
+	// Создаём базу данных, если её нет
+	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+	if err != nil {
+		log.Printf("Ошибка создания БД (возможно, уже существует): %v", err)
+	}
+}
+
+func mustGormOpen(connectionString string) *gorm.DB {
+	pgGorm, err := gorm.Open(postgres.New(
+		postgres.Config{
+			DSN:                  connectionString,
+			PreferSimpleProtocol: true,
+		},
+	), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("connection to postgres through gorm\n: %s", err)
+	}
+	return pgGorm
+}
+
+func mustAutoMigrate(db *gorm.DB) {
+	err := db.AutoMigrate(&courierrepo.CourierDTO{})
+	if err != nil {
+		log.Fatalf("Ошибка миграции: %v", err)
+	}
+
+	err = db.AutoMigrate(&courierrepo.StoragePlaceDTO{})
+	if err != nil {
+		log.Fatalf("Ошибка миграции: %v", err)
+	}
+
+	err = db.AutoMigrate(&orderrepo.OrderDTO{})
+	if err != nil {
+		log.Fatalf("Ошибка миграции: %v", err)
+	}
 }

--- a/cmd/composition_root.go
+++ b/cmd/composition_root.go
@@ -1,9 +1,82 @@
 package cmd
 
+import (
+	"delivery/internal/adapters/out/postgres"
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/application/usecases/queries"
+
+	"gorm.io/gorm"
+)
+
 type CompositionRoot struct {
+	gormDB     *gorm.DB
+	uowFactory postgres.GormUnitOfWorkFactory
 }
 
-func NewCompositionRoot(_ Config) CompositionRoot {
-	app := CompositionRoot{}
-	return app
+func NewCompositionRoot(_ Config, gormDB *gorm.DB) CompositionRoot {
+	return CompositionRoot{
+		gormDB:     gormDB,
+		uowFactory: *postgres.NewGormUnitOfWorkFactory(gormDB),
+	}
+}
+
+func (c *CompositionRoot) CreateAddCourierStorageCommandHandler() commands.AddCourierStorageCommandHandler {
+	var f commands.CourierUoWFactory = FuncCourierUoWFactory(func() commands.CourierUoW {
+		return c.uowFactory.Create()
+	})
+	return commands.NewAddCourierStorageCommandHandler(f)
+}
+
+func (c *CompositionRoot) CreateCreateCourierCommandHandler() commands.CreateCourierCommandHandler {
+	var f commands.CourierUoWFactory = FuncCourierUoWFactory(func() commands.CourierUoW {
+		return c.uowFactory.Create()
+	})
+	return commands.NewCreateCourierCommandHandler(f)
+}
+
+func (c *CompositionRoot) CreateCreateOrderCommandHandler() commands.CreateOrderCommandHandler {
+	var f commands.OrderUoWFactory = FuncOrderUoWFactory(func() commands.OrderUoW {
+		return c.uowFactory.Create()
+	})
+	return commands.NewCreateOrderCommandHandler(f)
+}
+
+func (c *CompositionRoot) CreateMoveCouriersCommandHandler() commands.MoveCouriersCommandHandler {
+	var f commands.UoWFactory = FuncUoWFactory(func() commands.UoW {
+		return c.uowFactory.Create()
+	})
+	return commands.NewMoveCouriersCommandHandler(f)
+}
+
+func (c *CompositionRoot) CreateAssignCourierCommandHandler() commands.AssignCourierCommandHandler {
+	var f commands.UoWFactory = FuncUoWFactory(func() commands.UoW {
+		return c.uowFactory.Create()
+	})
+	return commands.NewAssignCourierCommandHandler(f)
+}
+
+func (c *CompositionRoot) CreateGetAllCouriersQueryHandler() queries.GetAllCouriersQueryHandler {
+	return queries.NewGetAllCouriersQueryHandler(c.gormDB)
+}
+
+func (c *CompositionRoot) CreateGetUncompletedOrdersQueryHandler() queries.GetUncompletedOrdersQueryHandler {
+	return queries.NewGetUncompletedOrdersQueryHandler(c.gormDB)
+}
+
+type FuncCourierUoWFactory func() commands.CourierUoW
+
+func (f FuncCourierUoWFactory) Create() commands.CourierUoW {
+	return f()
+}
+
+type FuncOrderUoWFactory func() commands.OrderUoW
+
+func (f FuncOrderUoWFactory) Create() commands.OrderUoW {
+	return f()
+}
+
+type FuncUoWFactory func() commands.UoW
+
+func (f FuncUoWFactory) Create() commands.UoW {
+	return f()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module delivery
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/internal/adapters/out/postgres/unit_of_work_integration_test.go
+++ b/internal/adapters/out/postgres/unit_of_work_integration_test.go
@@ -131,7 +131,7 @@ func (suite *UnitOfWorkIntegrationTestSuite) TestUnitOfWork_TransactionErrors() 
 
 	// Test rollback without begin
 	err = uow.Rollback(ctx)
-	suite.Require().Error(err, "Should error when rolling back without active transaction")
+	suite.Require().NoError(err, "Should not error when rolling back without active transaction")
 }
 
 // TestUnitOfWork_SingleRepositoryTransaction verifies repository operations

--- a/internal/core/application/usecases/commands/add_courier_storage_command.go
+++ b/internal/core/application/usecases/commands/add_courier_storage_command.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"errors"
+
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/pkg/guard"
+)
+
+var (
+	ErrAddCourierStorageCommandIsNotConstructed = errors.New(
+		"AddCourierStorageCommand must be created via NewAddCourierStorageCommand constructor",
+	)
+	ErrTotalVolumeIsInvalid = errors.New("total volume must be greater than 0")
+)
+
+// AddCourierStorageCommand represents a request to add a new storage place to an existing courier.
+// This command encapsulates the business operation of expanding a courier's delivery capacity
+// by adding additional storage compartments.
+//
+// Example:
+//
+//	courierID := kernel.MustNewUUID("550e8400-e29b-41d4-a716-446655440000")
+//	cmd, err := NewAddCourierStorageCommand(courierID, "Insulated Box", 50)
+//	if err != nil {
+//	    return fmt.Errorf("invalid command: %w", err)
+//	}
+//
+//	handler := NewAddCourierStorageCommandHandler(uowFactory)
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("failed to add storage: %w", err)
+//	}
+type AddCourierStorageCommand struct { //nolint:recvcheck //using for validation
+	courierID   kernel.UUID
+	name        string
+	totalVolume int
+
+	guard guard.ConstructorGuard
+}
+
+// NewAddCourierStorageCommand creates a new command to add storage to a courier.
+// Validates that the courier ID is valid, name is not empty, and volume is positive.
+// Returns an error if any validation fails.
+func NewAddCourierStorageCommand(
+	courierID kernel.UUID,
+	name string,
+	totalVolume int,
+) (AddCourierStorageCommand, error) {
+	command := AddCourierStorageCommand{
+		guard: guard.NewConstructorGuard(),
+	}
+
+	if err := errors.Join(
+		command.setCourierID(courierID),
+		command.setName(name),
+		command.setTotalVolume(totalVolume),
+	); err != nil {
+		return AddCourierStorageCommand{}, err
+	}
+
+	return command, nil
+}
+
+// Validate ensures the command was created through the constructor.
+// Returns ErrAddCourierStorageCommandIsNotConstructed if validation fails.
+func (c AddCourierStorageCommand) Validate() error {
+	return c.guard.Validate(ErrAddCourierStorageCommandIsNotConstructed)
+}
+
+// CourierID returns the ID of the courier to add storage to.
+func (c AddCourierStorageCommand) CourierID() kernel.UUID {
+	return c.courierID
+}
+
+// Name returns the name of the storage place to be added.
+func (c AddCourierStorageCommand) Name() string {
+	return c.name
+}
+
+// TotalVolume returns the total volume capacity of the storage place.
+func (c AddCourierStorageCommand) TotalVolume() int {
+	return c.totalVolume
+}
+
+func (c *AddCourierStorageCommand) setCourierID(courierID kernel.UUID) error {
+	if err := courierID.Validate(); err != nil {
+		return err
+	}
+
+	c.courierID = courierID
+	return nil
+}
+
+func (c *AddCourierStorageCommand) setName(name string) error {
+	if name == "" {
+		return ErrNameIsRequired
+	}
+
+	c.name = name
+	return nil
+}
+
+func (c *AddCourierStorageCommand) setTotalVolume(totalVolume int) error {
+	if totalVolume <= 0 {
+		return ErrTotalVolumeIsInvalid
+	}
+
+	c.totalVolume = totalVolume
+	return nil
+}

--- a/internal/core/application/usecases/commands/add_courier_storage_command_handler.go
+++ b/internal/core/application/usecases/commands/add_courier_storage_command_handler.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"context"
+)
+
+// AddCourierStorageCommandHandler handles the business logic for adding storage places to couriers.
+// Uses transactional operations to ensure data consistency when modifying courier entities.
+//
+// Example:
+//
+//	handler := NewAddCourierStorageCommandHandler(uowFactory)
+//	cmd, _ := NewAddCourierStorageCommand(courierID, "Cold Storage", 30)
+//	err := handler.Handle(ctx, cmd)
+//	if err != nil {
+//	    log.Printf("Failed to add storage: %v", err)
+//	}
+type AddCourierStorageCommandHandler struct {
+	uowFactory CourierUoWFactory
+}
+
+// NewAddCourierStorageCommandHandler creates a new handler for adding storage to couriers.
+// Requires a CourierUoWFactory for transactional operations.
+func NewAddCourierStorageCommandHandler(uowFactory CourierUoWFactory) AddCourierStorageCommandHandler {
+	return AddCourierStorageCommandHandler{
+		uowFactory: uowFactory,
+	}
+}
+
+// Handle processes the AddCourierStorageCommand within a transaction.
+// Retrieves the courier, adds the new storage place, and persists the changes.
+// Automatically rolls back on any error to maintain data consistency.
+func (h *AddCourierStorageCommandHandler) Handle(ctx context.Context, cmd AddCourierStorageCommand) error {
+	if err := cmd.Validate(); err != nil {
+		return err
+	}
+
+	uow := h.uowFactory.Create()
+	if err := uow.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = uow.Rollback(ctx)
+	}()
+
+	courierRepo := uow.CourierRepository()
+	courierEntity, err := courierRepo.Get(ctx, cmd.CourierID())
+	if err != nil {
+		return err
+	}
+
+	if err = courierEntity.AddStoragePlace(cmd.Name(), cmd.TotalVolume()); err != nil {
+		return err
+	}
+
+	if err = courierRepo.Update(ctx, courierEntity); err != nil {
+		return err
+	}
+
+	if err = uow.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/core/application/usecases/commands/add_courier_storage_command_handler_test.go
+++ b/internal/core/application/usecases/commands/add_courier_storage_command_handler_test.go
@@ -1,0 +1,443 @@
+package commands_test
+
+import (
+	"errors"
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddCourierStorageCommandHandler(t *testing.T) {
+	// Arrange
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Act
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Assert
+	assert.NotNil(t, handler)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_Success(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	name := "Premium Storage"
+	totalVolume := 50
+
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, name, totalVolume)
+	require.NoError(t, err)
+
+	// Create a courier for the test
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+	courierEntity, err := courier.NewCourier(courierID, "Test Courier", 3, location)
+	require.NoError(t, err)
+
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Once(),
+		mockRepo.On("Update", ctx, courierEntity).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(nil).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.NoError(t, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+
+	// Verify storage was added to courier
+	storagePlaces := courierEntity.StoragePlaces()
+	found := false
+	for _, sp := range storagePlaces {
+		if sp.Name() == name && sp.TotalVolume() == totalVolume {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Storage place should be added to courier")
+}
+
+func TestAddCourierStorageCommandHandler_Handle_InvalidCommand(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	var invalidCmd commands.AddCourierStorageCommand // zero value command
+
+	mockFactory := new(MockCourierUoWFactory)
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err := handler.Handle(ctx, invalidCmd)
+
+	// Assert
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrAddCourierStorageCommandIsNotConstructed)
+	mockFactory.AssertExpectations(t) // No calls should be made to factory
+}
+
+func TestAddCourierStorageCommandHandler_Handle_BeginTransactionError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	expectedError := errors.New("begin transaction failed")
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockFactory.On("Create").Return(mockUoW).Once(),
+		mockUoW.On("Begin", ctx).Return(expectedError).Once(),
+	)
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_GetCourierError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	expectedError := errors.New("courier not found")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return((*courier.Courier)(nil), expectedError).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_AddStoragePlaceError(t *testing.T) {
+	// This test is simplified because the AddStoragePlace method in the courier domain
+	// doesn't have obvious validation failures with normal inputs.
+	// We'll test a scenario where the domain operation succeeds but could potentially fail
+
+	// Arrange
+	courierID := kernel.NewUUID()
+
+	// Test that a command with empty name fails during construction
+	_, err := commands.NewAddCourierStorageCommand(courierID, "", 50)
+	require.Error(t, err) // Command creation should fail with empty name
+	require.ErrorIs(t, err, commands.ErrNameIsRequired)
+
+	// Test that a command with invalid volume fails during construction
+	_, err = commands.NewAddCourierStorageCommand(courierID, "Storage", 0)
+	require.Error(t, err) // Command creation should fail with invalid volume
+	assert.ErrorIs(t, err, commands.ErrTotalVolumeIsInvalid)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_UpdateCourierError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+	courierEntity, err := courier.NewCourier(courierID, "Test Courier", 3, location)
+	require.NoError(t, err)
+
+	expectedError := errors.New("update failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Once(),
+		mockRepo.On("Update", ctx, courierEntity).Return(expectedError).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_CommitError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+	courierEntity, err := courier.NewCourier(courierID, "Test Courier", 3, location)
+	require.NoError(t, err)
+
+	expectedError := errors.New("commit failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Once(),
+		mockRepo.On("Update", ctx, courierEntity).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(expectedError).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_GetErrorWithRollbackError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	getError := errors.New("get failed")
+	rollbackError := errors.New("rollback failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return((*courier.Courier)(nil), getError).Once(),
+		mockUoW.On("Rollback", ctx).Return(rollbackError).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	// Should return the original get error, not the rollback error
+	require.Error(t, err)
+	assert.Equal(t, getError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_CommitErrorWithRollbackError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+	courierEntity, err := courier.NewCourier(courierID, "Test Courier", 3, location)
+	require.NoError(t, err)
+
+	commitError := errors.New("commit failed")
+	rollbackError := errors.New("rollback failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Once(),
+		mockRepo.On("Update", ctx, courierEntity).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(commitError).Once(),
+		mockUoW.On("Rollback", ctx).Return(rollbackError).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	// Should return the original commit error, not the rollback error
+	require.Error(t, err)
+	assert.Equal(t, commitError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestAddCourierStorageCommandHandler_Handle_VerifiesStorageAddedCorrectly(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	courierID := kernel.NewUUID()
+	storageName := "Premium Container"
+	storageVolume := 75
+
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, storageName, storageVolume)
+	require.NoError(t, err)
+
+	location, err := kernel.NewLocation(3, 8)
+	require.NoError(t, err)
+	courierEntity, err := courier.NewCourier(courierID, "Alice Johnson", 5, location)
+	require.NoError(t, err)
+
+	// Count initial storage places
+	initialStorageCount := len(courierEntity.StoragePlaces())
+
+	var capturedCourier *courier.Courier
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order with custom matcher to capture the courier
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Once(),
+		mockRepo.On("Update", ctx, mock.MatchedBy(func(c *courier.Courier) bool {
+			capturedCourier = c
+			return true
+		})).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(nil).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, capturedCourier)
+
+	// Verify the storage was added correctly
+	finalStoragePlaces := capturedCourier.StoragePlaces()
+	assert.Len(t, finalStoragePlaces, initialStorageCount+1)
+
+	// Find the newly added storage
+	found := false
+	for _, sp := range finalStoragePlaces {
+		if sp.Name() == storageName && sp.TotalVolume() == storageVolume {
+			found = true
+			assert.Nil(t, sp.OrderID()) // New storage should be empty
+			break
+		}
+	}
+	assert.True(t, found, "New storage place should be found with correct properties")
+
+	// Verify courier is still valid
+	require.NoError(t, capturedCourier.Validate())
+
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+// Benchmark test to ensure performance is acceptable.
+func BenchmarkAddCourierStorageCommandHandler_Handle(b *testing.B) {
+	ctx := b.Context()
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Benchmark Storage", 50)
+	require.NoError(b, err)
+
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(b, err)
+	courierEntity, err := courier.NewCourier(courierID, "Benchmark Courier", 3, location)
+	require.NoError(b, err)
+
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations for benchmarking
+	mockFactory.On("Create").Return(mockUoW).Times(b.N)
+	mockUoW.On("Begin", ctx).Return(nil).Times(b.N)
+	mockUoW.On("CourierRepository").Return(mockRepo).Times(b.N)
+	mockRepo.On("Get", ctx, courierID).Return(courierEntity, nil).Times(b.N)
+	mockRepo.On("Update", ctx, courierEntity).Return(nil).Times(b.N)
+	mockUoW.On("Commit", ctx).Return(nil).Times(b.N)
+	mockUoW.On("Rollback", ctx).Return(nil).Times(b.N)
+
+	handler := commands.NewAddCourierStorageCommandHandler(mockFactory)
+
+	b.ResetTimer()
+	for range b.N {
+		benchErr := handler.Handle(ctx, cmd)
+		if benchErr != nil {
+			b.Fatal(benchErr)
+		}
+	}
+}

--- a/internal/core/application/usecases/commands/add_courier_storage_command_test.go
+++ b/internal/core/application/usecases/commands/add_courier_storage_command_test.go
@@ -1,0 +1,361 @@
+package commands_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddCourierStorageCommand_ValidInput(t *testing.T) {
+	// Arrange
+	courierID := kernel.NewUUID()
+	name := "Thermal Bag"
+	totalVolume := 50
+
+	// Act
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, name, totalVolume)
+
+	// Assert
+	require.NoError(t, err)
+	assert.NotZero(t, cmd)
+	assert.Equal(t, courierID, cmd.CourierID())
+	assert.Equal(t, name, cmd.Name())
+	assert.Equal(t, totalVolume, cmd.TotalVolume())
+	assert.NoError(t, cmd.Validate())
+}
+
+func TestNewAddCourierStorageCommand_ValidInputBoundaryValues(t *testing.T) {
+	testCases := []struct {
+		name        string
+		storageName string
+		totalVolume int
+	}{
+		{
+			name:        "minimum volume",
+			storageName: "Small Bag",
+			totalVolume: 1,
+		},
+		{
+			name:        "large volume",
+			storageName: "Large Container",
+			totalVolume: 1000,
+		},
+		{
+			name:        "single character name",
+			storageName: "X",
+			totalVolume: 10,
+		},
+		{
+			name:        "long storage name",
+			storageName: "Very Long Storage Container Name With Many Characters For Testing",
+			totalVolume: 100,
+		},
+		{
+			name:        "storage with special characters",
+			storageName: "Thermal Bag #1 (Large)",
+			totalVolume: 75,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			courierID := kernel.NewUUID()
+
+			// Act
+			cmd, err := commands.NewAddCourierStorageCommand(courierID, tc.storageName, tc.totalVolume)
+
+			// Assert
+			require.NoError(t, err)
+			assert.NotZero(t, cmd)
+			assert.Equal(t, courierID, cmd.CourierID())
+			assert.Equal(t, tc.storageName, cmd.Name())
+			assert.Equal(t, tc.totalVolume, cmd.TotalVolume())
+			assert.NoError(t, cmd.Validate())
+		})
+	}
+}
+
+func TestNewAddCourierStorageCommand_InvalidCourierID(t *testing.T) {
+	// Arrange
+	var invalidCourierID kernel.UUID // zero value
+	name := "Storage"
+	totalVolume := 50
+
+	// Act
+	_, err := commands.NewAddCourierStorageCommand(invalidCourierID, name, totalVolume)
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, kernel.ErrUUIDIsNotConstructed)
+}
+
+func TestNewAddCourierStorageCommand_EmptyName(t *testing.T) {
+	// Arrange
+	courierID := kernel.NewUUID()
+	totalVolume := 50
+
+	// Act
+	_, err := commands.NewAddCourierStorageCommand(courierID, "", totalVolume)
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, commands.ErrNameIsRequired)
+}
+
+func TestNewAddCourierStorageCommand_InvalidTotalVolume(t *testing.T) {
+	testCases := []struct {
+		name        string
+		totalVolume int
+	}{
+		{
+			name:        "zero volume",
+			totalVolume: 0,
+		},
+		{
+			name:        "negative volume",
+			totalVolume: -1,
+		},
+		{
+			name:        "very negative volume",
+			totalVolume: -100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			courierID := kernel.NewUUID()
+			name := "Storage"
+
+			// Act
+			_, err := commands.NewAddCourierStorageCommand(courierID, name, tc.totalVolume)
+
+			// Assert
+			require.Error(t, err)
+			assert.ErrorIs(t, err, commands.ErrTotalVolumeIsInvalid)
+		})
+	}
+}
+
+func TestNewAddCourierStorageCommand_MultipleCombinedErrors(t *testing.T) {
+	// Arrange
+	var invalidCourierID kernel.UUID // zero value
+
+	// Act
+	_, err := commands.NewAddCourierStorageCommand(invalidCourierID, "", 0)
+
+	// Assert
+	require.Error(t, err)
+	// Should contain multiple errors - courier ID, name and total volume validation failures
+	assert.Contains(t, err.Error(), "UUID must be created via NewUUID, UUIDFromString, or UUIDFromBytes")
+	assert.Contains(t, err.Error(), "name is required")
+	assert.Contains(t, err.Error(), "total volume must be greater than 0")
+}
+
+func TestNewAddCourierStorageCommand_PartialErrors(t *testing.T) {
+	testCases := []struct {
+		name         string
+		courierID    kernel.UUID
+		storageName  string
+		totalVolume  int
+		expectedErrs []string
+	}{
+		{
+			name:        "invalid courier ID and empty name",
+			courierID:   kernel.UUID{}, // zero value
+			storageName: "",
+			totalVolume: 50,
+			expectedErrs: []string{
+				"UUID must be created via NewUUID, UUIDFromString, or UUIDFromBytes",
+				"name is required",
+			},
+		},
+		{
+			name:        "invalid courier ID and invalid volume",
+			courierID:   kernel.UUID{}, // zero value
+			storageName: "Storage",
+			totalVolume: -5,
+			expectedErrs: []string{
+				"UUID must be created via NewUUID, UUIDFromString, or UUIDFromBytes",
+				"total volume must be greater than 0",
+			},
+		},
+		{
+			name:        "empty name and invalid volume",
+			courierID:   kernel.NewUUID(),
+			storageName: "",
+			totalVolume: 0,
+			expectedErrs: []string{
+				"name is required",
+				"total volume must be greater than 0",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			_, err := commands.NewAddCourierStorageCommand(tc.courierID, tc.storageName, tc.totalVolume)
+
+			// Assert
+			require.Error(t, err)
+			for _, expectedErr := range tc.expectedErrs {
+				assert.Contains(t, err.Error(), expectedErr)
+			}
+		})
+	}
+}
+
+func TestAddCourierStorageCommand_Validate_Success(t *testing.T) {
+	// Arrange
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(t, err)
+
+	// Act
+	err = cmd.Validate()
+
+	// Assert
+	assert.NoError(t, err)
+}
+
+func TestAddCourierStorageCommand_Validate_ZeroValue(t *testing.T) {
+	// Arrange
+	var cmd commands.AddCourierStorageCommand // zero value
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, commands.ErrAddCourierStorageCommandIsNotConstructed)
+}
+
+func TestAddCourierStorageCommand_Validate_ErrorType(t *testing.T) {
+	// Arrange
+	var cmd commands.AddCourierStorageCommand // zero value
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.Error(t, err)
+
+	// Test that ErrAddCourierStorageCommandIsNotConstructed is the specific error returned
+	expectedErr := commands.ErrAddCourierStorageCommandIsNotConstructed
+	assert.Equal(
+		t,
+		"AddCourierStorageCommand must be created via NewAddCourierStorageCommand constructor",
+		expectedErr.Error(),
+	)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestAddCourierStorageCommand_GetterMethods(t *testing.T) {
+	// Arrange
+	courierID := kernel.NewUUID()
+	name := "Premium Storage"
+	totalVolume := 150
+
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, name, totalVolume)
+	require.NoError(t, err)
+
+	// Act & Assert
+	assert.Equal(t, courierID, cmd.CourierID())
+	assert.Equal(t, name, cmd.Name())
+	assert.Equal(t, totalVolume, cmd.TotalVolume())
+}
+
+func TestAddCourierStorageCommand_GetterMethods_ZeroValueReturnsDefaults(t *testing.T) {
+	// Arrange
+	var cmd commands.AddCourierStorageCommand // zero value
+
+	// Act & Assert
+	assert.Zero(t, cmd.CourierID())
+	assert.Empty(t, cmd.Name())
+	assert.Zero(t, cmd.TotalVolume())
+}
+
+func TestAddCourierStorageCommand_ImmutabilityAfterCreation(t *testing.T) {
+	// Arrange
+	courierID := kernel.NewUUID()
+	originalName := "Original Storage"
+	originalVolume := 100
+
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, originalName, originalVolume)
+	require.NoError(t, err)
+
+	// Act - Get values multiple times
+	name1 := cmd.Name()
+	name2 := cmd.Name()
+	volume1 := cmd.TotalVolume()
+	volume2 := cmd.TotalVolume()
+	id1 := cmd.CourierID()
+	id2 := cmd.CourierID()
+
+	// Assert - Values should remain consistent
+	assert.Equal(t, name1, name2)
+	assert.Equal(t, volume1, volume2)
+	assert.True(t, id1.IsEqual(id2))
+	assert.Equal(t, originalName, name1)
+	assert.Equal(t, originalVolume, volume1)
+	assert.True(t, courierID.IsEqual(id1))
+}
+
+func TestAddCourierStorageCommand_ErrorConstants(t *testing.T) {
+	// Test that error constants have expected messages
+	testCases := []struct {
+		name        string
+		err         error
+		expectedMsg string
+	}{
+		{
+			name:        "ErrAddCourierStorageCommandIsNotConstructed",
+			err:         commands.ErrAddCourierStorageCommandIsNotConstructed,
+			expectedMsg: "AddCourierStorageCommand must be created via NewAddCourierStorageCommand constructor",
+		},
+		{
+			name:        "ErrTotalVolumeIsInvalid",
+			err:         commands.ErrTotalVolumeIsInvalid,
+			expectedMsg: "total volume must be greater than 0",
+		},
+		{
+			name:        "ErrNameIsRequired",
+			err:         commands.ErrNameIsRequired,
+			expectedMsg: "name is required",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedMsg, tc.err.Error())
+		})
+	}
+}
+
+func BenchmarkNewAddCourierStorageCommand(b *testing.B) {
+	courierID := kernel.NewUUID()
+	name := "Storage"
+	totalVolume := 50
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = commands.NewAddCourierStorageCommand(courierID, name, totalVolume)
+	}
+}
+
+func BenchmarkAddCourierStorageCommand_Validate(b *testing.B) {
+	courierID := kernel.NewUUID()
+	cmd, err := commands.NewAddCourierStorageCommand(courierID, "Storage", 50)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = cmd.Validate()
+	}
+}

--- a/internal/core/application/usecases/commands/assign_courier_command.go
+++ b/internal/core/application/usecases/commands/assign_courier_command.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"delivery/internal/pkg/guard"
+	"errors"
+)
+
+var ErrAssignCourierCommandIsNotConstructed = errors.New(
+	"AssignCourierCommand must be created via NewAssignCourierCommand constructor",
+)
+
+// AssignCourierCommand triggers the assignment of an available courier to a pending order.
+// This command represents the business operation of matching delivery resources with orders.
+// It finds the first order in "created" status and assigns the most suitable courier.
+//
+// Example:
+//
+//	cmd := NewAssignCourierCommand()
+//	handler := NewAssignCourierCommandHandler(uowFactory, dispatcher)
+//	err := handler.Handle(ctx, cmd)
+//	if err != nil {
+//	    log.Printf("No orders to assign or no available couriers: %v", err)
+//	}
+type AssignCourierCommand struct {
+	guard guard.ConstructorGuard
+}
+
+// NewAssignCourierCommand creates a new command to trigger courier assignment.
+// This is a parameterless command that initiates the courier-order matching process.
+func NewAssignCourierCommand() AssignCourierCommand {
+	return AssignCourierCommand{
+		guard: guard.NewConstructorGuard(),
+	}
+}
+
+// Validate ensures the command was created through the constructor.
+// Returns ErrAssignCourierCommandIsNotConstructed if validation fails.
+func (c *AssignCourierCommand) Validate() error {
+	return c.guard.Validate(
+		ErrAssignCourierCommandIsNotConstructed,
+	)
+}

--- a/internal/core/application/usecases/commands/assign_courier_command_handler.go
+++ b/internal/core/application/usecases/commands/assign_courier_command_handler.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"context"
+	"delivery/internal/core/domain/services"
+	"delivery/internal/pkg/errs"
+	"errors"
+)
+
+var (
+	ErrNoFreeCouriersFound = errors.New("no free couriers found")
+	ErrNoOrderFound        = errors.New("no order found")
+)
+
+// AssignCourierCommandHandler orchestrates the courier assignment process.
+// Finds pending orders and matches them with available couriers using business rules.
+// Ensures transactional consistency when updating both order and courier states.
+//
+// Example:
+//
+//	handler := NewAssignCourierCommandHandler(uowFactory)
+//	cmd := NewAssignCourierCommand()
+//	err := handler.Handle(ctx, cmd)
+//	switch {
+//	case errors.Is(err, ErrNoOrderFound):
+//	    log.Println("No pending orders")
+//	case errors.Is(err, ErrNoFreeCouriersFound):
+//	    log.Println("All couriers are busy")
+//	case err != nil:
+//	    log.Printf("Assignment failed: %v", err)
+//	default:
+//	    log.Println("Courier assigned successfully")
+//	}
+type AssignCourierCommandHandler struct {
+	uowFactory UoWFactory
+}
+
+// NewAssignCourierCommandHandler creates a handler for courier assignment operations.
+// Requires a UoWFactory for coordinating transactional updates across repositories.
+func NewAssignCourierCommandHandler(uowFactory UoWFactory) AssignCourierCommandHandler {
+	return AssignCourierCommandHandler{
+		uowFactory: uowFactory,
+	}
+}
+
+// Handle processes the courier assignment command.
+// Retrieves the first pending order, finds available couriers, and uses OrderDispatcher
+// to select the best match. Updates both entities within a single transaction.
+// Returns specific errors for no orders (ErrNoOrderFound) or no couriers (ErrNoFreeCouriersFound).
+func (h AssignCourierCommandHandler) Handle(ctx context.Context, command AssignCourierCommand) error {
+	if err := command.Validate(); err != nil {
+		return err
+	}
+
+	uow := h.uowFactory.Create()
+	if err := uow.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = uow.Rollback(ctx)
+	}()
+
+	courierRepo := uow.CourierRepository()
+	ordersRepo := uow.OrderRepository()
+
+	order, err := ordersRepo.GetFirstInCreatedStatus(ctx)
+	if errors.Is(err, errs.ErrObjectNotFound) {
+		return ErrNoOrderFound
+	}
+	if err != nil {
+		return err
+	}
+
+	couriers, err := courierRepo.GetAllFree(ctx)
+	if err != nil {
+		return err
+	}
+	if len(couriers) == 0 {
+		return ErrNoFreeCouriersFound
+	}
+
+	assignedCourier, err := services.NewOrderDispatcher().Dispatch(order, couriers)
+	if err != nil {
+		return err
+	}
+
+	if err = ordersRepo.Update(ctx, order); err != nil {
+		return err
+	}
+
+	if err = courierRepo.Update(ctx, assignedCourier); err != nil {
+		return err
+	}
+
+	if err = uow.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/core/application/usecases/commands/assign_courier_command_handler_test.go
+++ b/internal/core/application/usecases/commands/assign_courier_command_handler_test.go
@@ -1,0 +1,512 @@
+package commands_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+	"delivery/internal/core/domain/services"
+	"delivery/internal/core/ports"
+	"delivery/internal/pkg/errs"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MockAssignCourierRepository struct{ mock.Mock }
+
+func (m *MockAssignCourierRepository) Add(ctx context.Context, c *courier.Courier) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MockAssignCourierRepository) Update(ctx context.Context, c *courier.Courier) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MockAssignCourierRepository) Get(ctx context.Context, id kernel.UUID) (*courier.Courier, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*courier.Courier), args.Error(1)
+}
+
+func (m *MockAssignCourierRepository) GetAllFree(ctx context.Context) ([]*courier.Courier, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*courier.Courier), args.Error(1)
+}
+
+type MockAssignOrderRepository struct{ mock.Mock }
+
+func (m *MockAssignOrderRepository) Add(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+
+func (m *MockAssignOrderRepository) Update(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+
+func (m *MockAssignOrderRepository) Get(ctx context.Context, id kernel.UUID) (*order.Order, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MockAssignOrderRepository) GetFirstInCreatedStatus(ctx context.Context) (*order.Order, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MockAssignOrderRepository) GetAllInAssignedStatus(ctx context.Context) ([]*order.Order, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*order.Order), args.Error(1)
+}
+
+type MockAssignUoW struct{ mock.Mock }
+
+func (m *MockAssignUoW) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockAssignUoW) Commit(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockAssignUoW) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockAssignUoW) OrderRepository() ports.OrderRepository {
+	args := m.Called()
+	return args.Get(0).(ports.OrderRepository)
+}
+
+func (m *MockAssignUoW) CourierRepository() ports.CourierRepository {
+	args := m.Called()
+	return args.Get(0).(ports.CourierRepository)
+}
+
+type MockAssignUoWFactory struct{ mock.Mock }
+
+func (m *MockAssignUoWFactory) Create() commands.UoW {
+	args := m.Called()
+	return args.Get(0).(commands.UoW)
+}
+
+func TestAssignCourierCommandHandler_Handle_Success(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	// Create test data
+	orderID := kernel.NewUUID()
+	courierID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+	testCourier, _ := courier.NewCourier(courierID, "John Doe", 3, location)
+	testCouriers := []*courier.Courier{testCourier}
+
+	// Setup mocks
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		orderRepo.On("Update", ctx, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		courierRepo.On("Update", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.NoError(t, err)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	factory.AssertExpectations(t)
+}
+
+func TestAssignCourierCommandHandler_Handle_ValidationError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.AssignCourierCommand{} // not constructed properly
+
+	factory := new(MockAssignUoWFactory)
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrAssignCourierCommandIsNotConstructed)
+	factory.AssertNotCalled(t, "Create")
+}
+
+func TestAssignCourierCommandHandler_Handle_BeginError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	uow := new(MockAssignUoW)
+	factory := new(MockAssignUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(errors.New("begin error")).Once(),
+	)
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "begin error")
+}
+
+func TestAssignCourierCommandHandler_Handle_NoOrderFound(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(nil, errs.ErrObjectNotFound).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrNoOrderFound)
+}
+
+func TestAssignCourierCommandHandler_Handle_GetOrderError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(nil, errors.New("database error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "database error")
+}
+
+func TestAssignCourierCommandHandler_Handle_NoFreeCouriers(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return([]*courier.Courier{}, nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrNoFreeCouriersFound)
+}
+
+func TestAssignCourierCommandHandler_Handle_GetCouriersError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(nil, errors.New("database error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "database error")
+}
+
+func TestAssignCourierCommandHandler_Handle_DispatchError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+	testOrder, _ := order.NewOrder(orderID, location, 1000) // Too heavy
+
+	courierID := kernel.NewUUID()
+	testCourier, _ := courier.NewCourier(courierID, "John Doe", 3, location)
+	testCouriers := []*courier.Courier{testCourier}
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrCourierNotFound)
+}
+
+func TestAssignCourierCommandHandler_Handle_UpdateOrderError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	courierID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+	testCourier, _ := courier.NewCourier(courierID, "John Doe", 3, location)
+	testCouriers := []*courier.Courier{testCourier}
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		orderRepo.On("Update", ctx, mock.AnythingOfType("*order.Order")).Return(errors.New("update error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "update error")
+}
+
+func TestAssignCourierCommandHandler_Handle_UpdateCourierError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	courierID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+	testCourier, _ := courier.NewCourier(courierID, "John Doe", 3, location)
+	testCouriers := []*courier.Courier{testCourier}
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		orderRepo.On("Update", ctx, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		courierRepo.On("Update", ctx, mock.AnythingOfType("*courier.Courier")).
+			Return(errors.New("update error")).
+			Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "update error")
+}
+
+func TestAssignCourierCommandHandler_Handle_CommitError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	courierID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+	testCourier, _ := courier.NewCourier(courierID, "John Doe", 3, location)
+	testCouriers := []*courier.Courier{testCourier}
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		orderRepo.On("Update", ctx, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		courierRepo.On("Update", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(errors.New("commit error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	require.EqualError(t, err, "commit error")
+}
+
+func TestAssignCourierCommandHandler_Handle_MultipleCouriers(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewAssignCourierCommand()
+
+	orderID := kernel.NewUUID()
+	location, _ := kernel.NewLocation(5, 7)
+	testOrder, _ := order.NewOrder(orderID, location, 10)
+
+	// Create multiple couriers at different locations
+	courier1ID := kernel.NewUUID()
+	courier2ID := kernel.NewUUID()
+	courier3ID := kernel.NewUUID()
+
+	// Create couriers at different locations for testing distance calculation
+	// Courier 2 will be closest to the order at (5,7)
+	loc1, _ := kernel.NewLocation(1, 1)   // Far away (corner)
+	loc2, _ := kernel.NewLocation(6, 7)   // Very close to order
+	loc3, _ := kernel.NewLocation(10, 10) // Medium distance (opposite corner)
+
+	testCourier1, err := courier.NewCourier(courier1ID, "John Doe", 3, loc1)
+	require.NoError(t, err)
+	testCourier2, err := courier.NewCourier(courier2ID, "Jane Smith", 3, loc2)
+	require.NoError(t, err)
+	testCourier3, err := courier.NewCourier(courier3ID, "Bob Wilson", 3, loc3)
+	require.NoError(t, err)
+
+	testCouriers := []*courier.Courier{testCourier1, testCourier2, testCourier3}
+
+	orderRepo := new(MockAssignOrderRepository)
+	courierRepo := new(MockAssignCourierRepository)
+	uow := new(MockAssignUoW)
+
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetFirstInCreatedStatus", ctx).Return(testOrder, nil).Once(),
+		courierRepo.On("GetAllFree", ctx).Return(testCouriers, nil).Once(),
+		orderRepo.On("Update", ctx, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		courierRepo.On("Update", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockAssignUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	handler := commands.NewAssignCourierCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.NoError(t, err)
+
+	// Verify that the courier with the nearest location was selected
+	updateCall := courierRepo.Calls[1]
+	updatedCourier := updateCall.Arguments[1].(*courier.Courier)
+	assert.Equal(t, courier2ID, updatedCourier.ID())
+}

--- a/internal/core/application/usecases/commands/assign_courier_command_test.go
+++ b/internal/core/application/usecases/commands/assign_courier_command_test.go
@@ -1,0 +1,31 @@
+package commands_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAssignCourierCommand_Success(t *testing.T) {
+	// Act
+	cmd := commands.NewAssignCourierCommand()
+
+	// Assert
+	assert.NotZero(t, cmd)
+	require.NoError(t, cmd.Validate())
+}
+
+func TestAssignCourierCommand_Validate_ZeroValue(t *testing.T) {
+	// Arrange
+	var cmd commands.AssignCourierCommand // zero value, not constructed via constructor
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrAssignCourierCommandIsNotConstructed)
+}

--- a/internal/core/application/usecases/commands/create_courier_command.go
+++ b/internal/core/application/usecases/commands/create_courier_command.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/pkg/guard"
+	"errors"
+)
+
+var (
+	ErrCreateCourierCommandIsNotConstructed = errors.New(
+		"CreateCourierCommand must be created via NewCreateCourierCommand constructor",
+	)
+	ErrNameIsRequired = errors.New("name is required")
+	ErrSpeedIsInvalid = errors.New("speed must be greater than 0")
+)
+
+// CreateCourierCommand represents a request to register a new courier in the delivery system.
+// Encapsulates all data needed to create a courier entity with delivery capabilities.
+//
+// Example:
+//
+//	location := kernel.NewLocation(55.7558, 37.6173) // Moscow coordinates
+//	cmd, err := NewCreateCourierCommand("John Doe", 60, location)
+//	if err != nil {
+//	    return fmt.Errorf("invalid courier data: %w", err)
+//	}
+//
+//	handler := NewCreateCourierCommandHandler(uowFactory)
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("failed to create courier: %w", err)
+//	}
+//	fmt.Printf("Created courier with ID: %s", cmd.CourierID())
+type CreateCourierCommand struct { //nolint:recvcheck //using for validation
+	courierID kernel.UUID
+	name      string
+	speed     int
+	location  kernel.Location
+
+	guard guard.ConstructorGuard
+}
+
+// NewCreateCourierCommand creates a command to register a new courier.
+// Automatically generates a unique ID for the courier.
+// Validates that name is not empty, speed is positive, and location is valid.
+func NewCreateCourierCommand(name string, speed int, location kernel.Location) (CreateCourierCommand, error) {
+	command := CreateCourierCommand{
+		guard: guard.NewConstructorGuard(),
+	}
+
+	if err := errors.Join(
+		command.setCourierID(kernel.NewUUID()),
+		command.setName(name),
+		command.setSpeed(speed),
+		command.setLocation(location),
+	); err != nil {
+		return CreateCourierCommand{}, err
+	}
+
+	return command, nil
+}
+
+// Validate ensures the command was created through the constructor.
+// Returns ErrCreateCourierCommandIsNotConstructed if validation fails.
+func (c CreateCourierCommand) Validate() error {
+	return c.guard.Validate(ErrCreateCourierCommandIsNotConstructed)
+}
+
+// CourierID returns the courier ID from the command.
+func (c CreateCourierCommand) CourierID() kernel.UUID {
+	return c.courierID
+}
+
+// Name returns the courier name from the command.
+func (c CreateCourierCommand) Name() string {
+	return c.name
+}
+
+// Speed returns the courier speed from the command.
+func (c CreateCourierCommand) Speed() int {
+	return c.speed
+}
+
+// Location returns the courier location from the command.
+func (c CreateCourierCommand) Location() kernel.Location {
+	return c.location
+}
+
+func (c *CreateCourierCommand) setCourierID(id kernel.UUID) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
+
+	c.courierID = id
+	return nil
+}
+
+func (c *CreateCourierCommand) setName(name string) error {
+	if name == "" {
+		return ErrNameIsRequired
+	}
+
+	c.name = name
+	return nil
+}
+
+func (c *CreateCourierCommand) setSpeed(speed int) error {
+	if speed <= 0 {
+		return ErrSpeedIsInvalid
+	}
+
+	c.speed = speed
+	return nil
+}
+
+func (c *CreateCourierCommand) setLocation(location kernel.Location) error {
+	if err := location.Validate(); err != nil {
+		return err
+	}
+
+	c.location = location
+	return nil
+}

--- a/internal/core/application/usecases/commands/create_courier_command_handler.go
+++ b/internal/core/application/usecases/commands/create_courier_command_handler.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"context"
+
+	"delivery/internal/core/domain/model/courier"
+)
+
+// CreateCourierCommandHandler handles the business logic for courier registration.
+// Creates and persists new courier entities with initial location and capabilities.
+//
+// Example:
+//
+//	handler := NewCreateCourierCommandHandler(uowFactory)
+//	location := kernel.NewLocation(40.7128, -74.0060) // New York
+//	cmd, _ := NewCreateCourierCommand("Express Courier", 80, location)
+//
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("courier registration failed: %w", err)
+//	}
+type CreateCourierCommandHandler struct {
+	uowFactory CourierUoWFactory
+}
+
+// NewCreateCourierCommandHandler creates a handler for courier registration.
+// Requires a CourierUoWFactory for transactional persistence operations.
+func NewCreateCourierCommandHandler(uowFactory CourierUoWFactory) CreateCourierCommandHandler {
+	return CreateCourierCommandHandler{
+		uowFactory: uowFactory,
+	}
+}
+
+// Handle processes the courier creation command.
+// Creates a new courier entity and persists it within a transaction.
+// Automatically rolls back on any error to prevent partial data.
+func (h *CreateCourierCommandHandler) Handle(ctx context.Context, cmd CreateCourierCommand) error {
+	if err := cmd.Validate(); err != nil {
+		return err
+	}
+
+	uow := h.uowFactory.Create()
+	if err := uow.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = uow.Rollback(ctx)
+	}()
+
+	courierRepo := uow.CourierRepository()
+	courierEntity, err := courier.NewCourier(cmd.CourierID(), cmd.Name(), cmd.Speed(), cmd.Location())
+	if err != nil {
+		return err
+	}
+
+	if err = courierRepo.Add(ctx, courierEntity); err != nil {
+		return err
+	}
+
+	if err = uow.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/core/application/usecases/commands/create_courier_command_handler_test.go
+++ b/internal/core/application/usecases/commands/create_courier_command_handler_test.go
@@ -1,0 +1,437 @@
+package commands_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/ports"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock implementations for testing.
+type MockCourierRepository struct {
+	mock.Mock
+}
+
+func (m *MockCourierRepository) Add(ctx context.Context, courier *courier.Courier) error {
+	args := m.Called(ctx, courier)
+	return args.Error(0)
+}
+
+func (m *MockCourierRepository) Update(ctx context.Context, courier *courier.Courier) error {
+	args := m.Called(ctx, courier)
+	return args.Error(0)
+}
+
+func (m *MockCourierRepository) Get(ctx context.Context, id kernel.UUID) (*courier.Courier, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(*courier.Courier), args.Error(1)
+}
+
+func (m *MockCourierRepository) GetAllFree(ctx context.Context) ([]*courier.Courier, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*courier.Courier), args.Error(1)
+}
+
+type MockCourierUoW struct {
+	mock.Mock
+}
+
+func (m *MockCourierUoW) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockCourierUoW) Commit(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockCourierUoW) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockCourierUoW) CourierRepository() ports.CourierRepository {
+	args := m.Called()
+	return args.Get(0).(ports.CourierRepository)
+}
+
+type MockCourierUoWFactory struct {
+	mock.Mock
+}
+
+func (m *MockCourierUoWFactory) Create() commands.CourierUoW {
+	args := m.Called()
+	return args.Get(0).(commands.CourierUoW)
+}
+
+func TestNewCreateCourierCommandHandler(t *testing.T) {
+	// Arrange
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Act
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Assert
+	assert.NotNil(t, handler)
+}
+
+func TestCreateCourierCommandHandler_Handle_Success(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(nil).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.NoError(t, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_InvalidCommand(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	var invalidCmd commands.CreateCourierCommand // zero value command
+
+	mockFactory := new(MockCourierUoWFactory)
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err := handler.Handle(ctx, invalidCmd)
+
+	// Assert
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrCreateCourierCommandIsNotConstructed)
+	mockFactory.AssertExpectations(t) // No calls should be made to factory
+}
+
+func TestCreateCourierCommandHandler_Handle_BeginTransactionError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	expectedError := errors.New("begin transaction failed")
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockFactory.On("Create").Return(mockUoW).Once(),
+		mockUoW.On("Begin", ctx).Return(expectedError).Once(),
+	)
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_CourierCreationError(t *testing.T) {
+	// Test case where courier.NewCourier fails - though this should not happen
+	// with a valid command, we test for completeness
+	// This test essentially covers the scenario where the domain model changes
+	// its validation rules but the command hasn't been updated accordingly
+	t.Skip("Skipping as courier.NewCourier should not fail with valid command data")
+}
+
+func TestCreateCourierCommandHandler_Handle_RepositoryAddError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	expectedError := errors.New("repository add failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(expectedError).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_CommitError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	expectedError := errors.New("commit failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(expectedError).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_RepositoryAddErrorWithRollbackError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	repoError := errors.New("repository add failed")
+	rollbackError := errors.New("rollback failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(repoError).Once(),
+		mockUoW.On("Rollback", ctx).Return(rollbackError).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	// Should return the original repository error, not the rollback error
+	require.Error(t, err)
+	assert.Equal(t, repoError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_CommitErrorWithRollbackError(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	commitError := errors.New("commit failed")
+	rollbackError := errors.New("rollback failed")
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(commitError).Once(),
+		mockUoW.On("Rollback", ctx).Return(rollbackError).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	// Should return the original commit error, not the rollback error
+	require.Error(t, err)
+	assert.Equal(t, commitError, err)
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_VerifiesCourierDataCorrectness(t *testing.T) {
+	// Arrange
+	ctx := t.Context()
+	name := "Alice Johnson"
+	speed := 5
+	location, err := kernel.NewLocation(3, 8)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	var capturedCourier *courier.Courier
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations in order with custom matcher to capture the courier
+	mock.InOrder(
+		mockUoW.On("Begin", ctx).Return(nil).Once(),
+		mockUoW.On("CourierRepository").Return(mockRepo).Once(),
+		mockRepo.On("Add", ctx, mock.MatchedBy(func(c *courier.Courier) bool {
+			capturedCourier = c
+			return true
+		})).Return(nil).Once(),
+		mockUoW.On("Commit", ctx).Return(nil).Once(),
+		mockUoW.On("Rollback", ctx).Return(nil).Once(),
+	)
+	mockFactory.On("Create").Return(mockUoW).Once()
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	// Act
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, capturedCourier)
+
+	// Verify the courier was created with correct data
+	assert.Equal(t, cmd.CourierID(), capturedCourier.ID())
+	assert.Equal(t, name, capturedCourier.Name())
+	assert.Equal(t, speed, capturedCourier.Speed())
+	assert.Equal(t, location, capturedCourier.Location())
+
+	// Verify courier is valid
+	require.NoError(t, capturedCourier.Validate())
+
+	mockFactory.AssertExpectations(t)
+	mockUoW.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestCreateCourierCommandHandler_Handle_MultipleCommandsGenerateUniqueIDs(t *testing.T) {
+	// Arrange
+	location, err := kernel.NewLocation(5, 5)
+	require.NoError(t, err)
+
+	cmd1, err := commands.NewCreateCourierCommand("Courier 1", 2, location)
+	require.NoError(t, err)
+
+	cmd2, err := commands.NewCreateCourierCommand("Courier 2", 3, location)
+	require.NoError(t, err)
+
+	// Assert
+	assert.NotEqual(t, cmd1.CourierID(), cmd2.CourierID(), "Different commands should generate unique courier IDs")
+}
+
+// Benchmark test to ensure performance is acceptable.
+func BenchmarkCreateCourierCommandHandler_Handle(b *testing.B) {
+	ctx := b.Context()
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(b, err)
+
+	cmd, err := commands.NewCreateCourierCommand("Benchmark Courier", 3, location)
+	require.NoError(b, err)
+
+	mockRepo := new(MockCourierRepository)
+	mockUoW := new(MockCourierUoW)
+	mockFactory := new(MockCourierUoWFactory)
+
+	// Set up expectations for benchmarking
+	mockFactory.On("Create").Return(mockUoW).Times(b.N)
+	mockUoW.On("Begin", ctx).Return(nil).Times(b.N)
+	mockUoW.On("CourierRepository").Return(mockRepo).Times(b.N)
+	mockRepo.On("Add", ctx, mock.AnythingOfType("*courier.Courier")).Return(nil).Times(b.N)
+	mockUoW.On("Commit", ctx).Return(nil).Times(b.N)
+	mockUoW.On("Rollback", ctx).Return(nil).Times(b.N)
+
+	handler := commands.NewCreateCourierCommandHandler(mockFactory)
+
+	b.ResetTimer()
+	for range b.N {
+		benchErr := handler.Handle(ctx, cmd)
+		if benchErr != nil {
+			b.Fatal(benchErr)
+		}
+	}
+}

--- a/internal/core/application/usecases/commands/create_courier_command_test.go
+++ b/internal/core/application/usecases/commands/create_courier_command_test.go
@@ -1,0 +1,411 @@
+package commands_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCreateCourierCommand_ValidInput(t *testing.T) {
+	// Arrange
+	name := "John Doe"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	// Act
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+
+	// Assert
+	require.NoError(t, err)
+	assert.NotZero(t, cmd)
+	assert.Equal(t, name, cmd.Name())
+	assert.Equal(t, speed, cmd.Speed())
+	assert.Equal(t, location, cmd.Location())
+	assert.NotZero(t, cmd.CourierID())
+
+	// Verify the courier ID is valid
+	assert.NoError(t, cmd.CourierID().Validate())
+}
+
+func TestNewCreateCourierCommand_ValidInputBoundaryValues(t *testing.T) {
+	// Test with boundary location values
+	testCases := []struct {
+		name        string
+		courierName string
+		speed       int
+		x, y        kernel.Coordinate
+	}{
+		{
+			name:        "min coordinates",
+			courierName: "Courier A",
+			speed:       1,
+			x:           kernel.LocationMinX,
+			y:           kernel.LocationMinY,
+		},
+		{
+			name:        "max coordinates",
+			courierName: "Courier B",
+			speed:       5,
+			x:           kernel.LocationMaxX,
+			y:           kernel.LocationMaxY,
+		},
+		{
+			name:        "single character name",
+			courierName: "X",
+			speed:       2,
+			x:           5,
+			y:           5,
+		},
+		{
+			name:        "long name",
+			courierName: "Very Long Courier Name With Many Characters",
+			speed:       10,
+			x:           3,
+			y:           8,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			location, err := kernel.NewLocation(tc.x, tc.y)
+			require.NoError(t, err)
+
+			// Act
+			cmd, err := commands.NewCreateCourierCommand(tc.courierName, tc.speed, location)
+
+			// Assert
+			require.NoError(t, err)
+			assert.NotZero(t, cmd)
+			assert.Equal(t, tc.courierName, cmd.Name())
+			assert.Equal(t, tc.speed, cmd.Speed())
+			assert.Equal(t, location, cmd.Location())
+			assert.NotZero(t, cmd.CourierID())
+			assert.NoError(t, cmd.CourierID().Validate())
+		})
+	}
+}
+
+func TestNewCreateCourierCommand_EmptyName(t *testing.T) {
+	// Arrange
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	// Act
+	_, err = commands.NewCreateCourierCommand("", speed, location)
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, commands.ErrNameIsRequired)
+}
+
+func TestNewCreateCourierCommand_InvalidSpeed(t *testing.T) {
+	testCases := []struct {
+		name  string
+		speed int
+	}{
+		{
+			name:  "zero speed",
+			speed: 0,
+		},
+		{
+			name:  "negative speed",
+			speed: -1,
+		},
+		{
+			name:  "very negative speed",
+			speed: -100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			name := "John Doe"
+			location, err := kernel.NewLocation(5, 7)
+			require.NoError(t, err)
+
+			// Act
+			_, err = commands.NewCreateCourierCommand(name, tc.speed, location)
+
+			// Assert
+			require.Error(t, err)
+			assert.ErrorIs(t, err, commands.ErrSpeedIsInvalid)
+		})
+	}
+}
+
+func TestNewCreateCourierCommand_InvalidLocation_OutOfRangeX(t *testing.T) {
+	// Arrange
+	name := "John Doe"
+	speed := 3
+
+	// Act
+	_, err := commands.NewCreateCourierCommand(name, speed, kernel.Location{})
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, kernel.ErrLocationIsNotConstructed)
+}
+
+func TestNewCreateCourierCommand_InvalidLocation_ZeroValue(t *testing.T) {
+	// Arrange
+	name := "John Doe"
+	speed := 3
+	var invalidLocation kernel.Location // zero value
+
+	// Act
+	_, err := commands.NewCreateCourierCommand(name, speed, invalidLocation)
+
+	// Assert
+	require.Error(t, err)
+	assert.ErrorIs(t, err, kernel.ErrLocationIsNotConstructed)
+}
+
+func TestNewCreateCourierCommand_MultipleCombinedErrors(t *testing.T) {
+	// Arrange
+	var invalidLocation kernel.Location // zero value
+
+	// Act
+	_, err := commands.NewCreateCourierCommand("", 0, invalidLocation)
+
+	// Assert
+	require.Error(t, err)
+	// Should contain multiple errors - name, speed and location validation failures
+	assert.Contains(t, err.Error(), "name is required")
+	assert.Contains(t, err.Error(), "speed must be greater than 0")
+	assert.Contains(t, err.Error(), "location must be created via NewLocation or NewRandomLocation constructors")
+}
+
+func TestNewCreateCourierCommand_WithRandomLocation(t *testing.T) {
+	// Arrange
+	name := "Random Courier"
+	speed := 4
+	location, err := kernel.NewRandomLocation()
+	require.NoError(t, err)
+
+	// Act
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+
+	// Assert
+	require.NoError(t, err)
+	assert.NotZero(t, cmd)
+	assert.Equal(t, name, cmd.Name())
+	assert.Equal(t, speed, cmd.Speed())
+	assert.Equal(t, location, cmd.Location())
+	assert.NotZero(t, cmd.CourierID())
+	assert.NoError(t, cmd.CourierID().Validate())
+}
+
+func TestNewCreateCourierCommand_NameWithSpecialCharacters(t *testing.T) {
+	// Test names with various special characters
+	testCases := []struct {
+		name        string
+		courierName string
+		shouldPass  bool
+	}{
+		{
+			name:        "name with spaces",
+			courierName: "John Doe Smith",
+			shouldPass:  true,
+		},
+		{
+			name:        "name with hyphens",
+			courierName: "Jean-Pierre",
+			shouldPass:  true,
+		},
+		{
+			name:        "name with apostrophe",
+			courierName: "O'Connor",
+			shouldPass:  true,
+		},
+		{
+			name:        "name with numbers",
+			courierName: "Agent007",
+			shouldPass:  true,
+		},
+		{
+			name:        "name with unicode",
+			courierName: "José María",
+			shouldPass:  true,
+		},
+		{
+			name:        "name with special symbols",
+			courierName: "@#$%Courier",
+			shouldPass:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			speed := 2
+			location, err := kernel.NewLocation(5, 5)
+			require.NoError(t, err)
+
+			// Act
+			cmd, err := commands.NewCreateCourierCommand(tc.courierName, speed, location)
+
+			// Assert
+			if tc.shouldPass {
+				require.NoError(t, err)
+				assert.NotZero(t, cmd)
+				assert.Equal(t, tc.courierName, cmd.Name())
+				assert.Equal(t, speed, cmd.Speed())
+				assert.Equal(t, location, cmd.Location())
+				assert.NotZero(t, cmd.CourierID())
+				assert.NoError(t, cmd.CourierID().Validate())
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestNewCreateCourierCommand_SpeedBoundaryValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		speed      int
+		shouldPass bool
+	}{
+		{
+			name:       "minimum valid speed",
+			speed:      1,
+			shouldPass: true,
+		},
+		{
+			name:       "moderate speed",
+			speed:      5,
+			shouldPass: true,
+		},
+		{
+			name:       "high speed",
+			speed:      100,
+			shouldPass: true,
+		},
+		{
+			name:       "very high speed",
+			speed:      1000,
+			shouldPass: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			name := "Speed Test Courier"
+			location, err := kernel.NewLocation(5, 5)
+			require.NoError(t, err)
+
+			// Act
+			cmd, err := commands.NewCreateCourierCommand(name, tc.speed, location)
+
+			// Assert
+			if tc.shouldPass {
+				require.NoError(t, err)
+				assert.NotZero(t, cmd)
+				assert.Equal(t, name, cmd.Name())
+				assert.Equal(t, tc.speed, cmd.Speed())
+				assert.Equal(t, location, cmd.Location())
+				assert.NotZero(t, cmd.CourierID())
+				assert.NoError(t, cmd.CourierID().Validate())
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateCourierCommand_ErrorVariations(t *testing.T) {
+	// Test that ErrNameIsRequired is the specific error returned
+	t.Run("name error type verification", func(t *testing.T) {
+		location, err := kernel.NewLocation(5, 5)
+		require.NoError(t, err)
+
+		_, err = commands.NewCreateCourierCommand("", 3, location)
+
+		require.Error(t, err)
+		assert.Equal(t, "name is required", commands.ErrNameIsRequired.Error())
+		assert.ErrorIs(t, err, commands.ErrNameIsRequired)
+	})
+
+	// Test that ErrSpeedIsInvalid is the specific error returned
+	t.Run("speed error type verification", func(t *testing.T) {
+		location, err := kernel.NewLocation(5, 5)
+		require.NoError(t, err)
+
+		_, err = commands.NewCreateCourierCommand("John Doe", 0, location)
+
+		require.Error(t, err)
+		assert.Equal(t, "speed must be greater than 0", commands.ErrSpeedIsInvalid.Error())
+		assert.ErrorIs(t, err, commands.ErrSpeedIsInvalid)
+	})
+}
+
+func TestCreateCourierCommand_Validate_Success(t *testing.T) {
+	// Arrange
+	name := "Valid Courier"
+	speed := 3
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(t, err)
+
+	cmd, err := commands.NewCreateCourierCommand(name, speed, location)
+	require.NoError(t, err)
+
+	// Act
+	err = cmd.Validate()
+
+	// Assert
+	assert.NoError(t, err)
+}
+
+func TestCreateCourierCommand_Validate_ZeroValue(t *testing.T) {
+	// Arrange - zero value command (not constructed via constructor)
+	var cmd commands.CreateCourierCommand
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.Error(t, err)
+	require.ErrorIs(t, err, commands.ErrCreateCourierCommandIsNotConstructed)
+	assert.Equal(t,
+		"CreateCourierCommand must be created via NewCreateCourierCommand constructor",
+		commands.ErrCreateCourierCommandIsNotConstructed.Error(),
+	)
+}
+
+func TestCreateCourierCommand_Validate_ErrorType(t *testing.T) {
+	// Test that the specific error type is returned
+	t.Run("validation error type verification", func(t *testing.T) {
+		var cmd commands.CreateCourierCommand
+
+		err := cmd.Validate()
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, commands.ErrCreateCourierCommandIsNotConstructed)
+		assert.Contains(t, err.Error(), "CreateCourierCommand must be created via NewCreateCourierCommand constructor")
+	})
+}
+
+// Benchmark test to ensure performance is acceptable.
+func BenchmarkNewCreateCourierCommand(b *testing.B) {
+	location, err := kernel.NewLocation(5, 7)
+	require.NoError(b, err)
+	name := "Benchmark Courier"
+	speed := 3
+
+	b.ResetTimer()
+	for range b.N {
+		_, benchErr := commands.NewCreateCourierCommand(name, speed, location)
+		if benchErr != nil {
+			b.Fatal(benchErr)
+		}
+	}
+}

--- a/internal/core/application/usecases/commands/create_order_command.go
+++ b/internal/core/application/usecases/commands/create_order_command.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"errors"
+
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/pkg/guard"
+)
+
+var (
+	ErrCreateOrderCommandIsNotConstructed = errors.New(
+		"CreateOrderCommand must be created via NewCreateOrderCommand constructor",
+	)
+	ErrStreetIsRequired = errors.New("street is required")
+	ErrVolumeIsInvalid  = errors.New("volume must be greater than 0")
+)
+
+// CreateOrderCommand represents a request to create a new delivery order.
+// Encapsulates order details including destination and package volume requirements.
+//
+// Example:
+//
+//	orderID := kernel.NewUUID()
+//	cmd, err := NewCreateOrderCommand(orderID, "123 Main Street", 25)
+//	if err != nil {
+//	    return fmt.Errorf("invalid order data: %w", err)
+//	}
+//
+//	handler := NewCreateOrderCommandHandler(uowFactory)
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("failed to create order: %w", err)
+//	}
+//	fmt.Printf("Order %s created and awaiting courier assignment", orderID)
+type CreateOrderCommand struct { //nolint:recvcheck //using for validation
+	orderID kernel.UUID
+	street  string
+	volume  int
+
+	guard guard.ConstructorGuard
+}
+
+// NewCreateOrderCommand creates a command to register a new delivery order.
+// Validates that order ID is valid, street is not empty, and volume is positive.
+// Returns an error if any validation fails.
+func NewCreateOrderCommand(orderID kernel.UUID, street string, volume int) (CreateOrderCommand, error) {
+	orderCommand := CreateOrderCommand{
+		guard: guard.NewConstructorGuard(),
+	}
+
+	if err := errors.Join(
+		orderCommand.setOrderID(orderID),
+		orderCommand.setStreet(street),
+		orderCommand.setVolume(volume),
+	); err != nil {
+		return CreateOrderCommand{}, err
+	}
+
+	return orderCommand, nil
+}
+
+// Validate ensures the command was created through the constructor.
+// Returns ErrCreateOrderCommandIsNotConstructed if validation fails.
+func (c CreateOrderCommand) Validate() error {
+	return c.guard.Validate(ErrCreateOrderCommandIsNotConstructed)
+}
+
+// OrderID returns the unique identifier for the order.
+func (c CreateOrderCommand) OrderID() kernel.UUID {
+	return c.orderID
+}
+
+// Street returns the delivery destination street address.
+func (c CreateOrderCommand) Street() string {
+	return c.street
+}
+
+// Volume returns the package volume in cubic units.
+func (c CreateOrderCommand) Volume() int {
+	return c.volume
+}
+
+func (c *CreateOrderCommand) setOrderID(orderID kernel.UUID) error {
+	if err := orderID.Validate(); err != nil {
+		return err
+	}
+
+	c.orderID = orderID
+	return nil
+}
+
+func (c *CreateOrderCommand) setStreet(street string) error {
+	if street == "" {
+		return ErrStreetIsRequired
+	}
+
+	c.street = street
+	return nil
+}
+
+func (c *CreateOrderCommand) setVolume(volume int) error {
+	if volume <= 0 {
+		return ErrVolumeIsInvalid
+	}
+
+	c.volume = volume
+	return nil
+}

--- a/internal/core/application/usecases/commands/create_order_command_handler.go
+++ b/internal/core/application/usecases/commands/create_order_command_handler.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"context"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+)
+
+// CreateOrderCommandHandler handles the business logic for order creation.
+// Creates new orders with random delivery locations and initial "created" status.
+//
+// Example:
+//
+//	handler := NewCreateOrderCommandHandler(uowFactory)
+//	orderID := kernel.NewUUID()
+//	cmd, _ := NewCreateOrderCommand(orderID, "456 Oak Avenue", 15)
+//
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("order creation failed: %w", err)
+//	}
+//	// Order is now created and ready for courier assignment
+type CreateOrderCommandHandler struct {
+	uowFactory OrderUoWFactory
+}
+
+// NewCreateOrderCommandHandler creates a handler for order creation operations.
+// Requires an OrderUoWFactory for transactional persistence.
+func NewCreateOrderCommandHandler(uowFactory OrderUoWFactory) CreateOrderCommandHandler {
+	return CreateOrderCommandHandler{
+		uowFactory: uowFactory,
+	}
+}
+
+// Handle processes the order creation command.
+// Generates a random delivery location and creates the order in "created" status.
+// Uses transaction to ensure order is properly persisted or rolled back on error.
+func (h *CreateOrderCommandHandler) Handle(ctx context.Context, cmd CreateOrderCommand) error {
+	if err := cmd.Validate(); err != nil {
+		return err
+	}
+
+	location, err := kernel.NewRandomLocation()
+	if err != nil {
+		return err
+	}
+
+	uow := h.uowFactory.Create()
+	if err = uow.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = uow.Rollback(ctx)
+	}()
+
+	orderRepo := uow.OrderRepository()
+	order, err := order.NewOrder(cmd.OrderID(), location, cmd.Volume())
+	if err != nil {
+		return err
+	}
+
+	if err = orderRepo.Add(ctx, order); err != nil {
+		return err
+	}
+
+	if err = uow.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/core/application/usecases/commands/create_order_command_handler_test.go
+++ b/internal/core/application/usecases/commands/create_order_command_handler_test.go
@@ -1,0 +1,162 @@
+package commands_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+	"delivery/internal/core/ports"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MockOrderRepository struct{ mock.Mock }
+
+func (m *MockOrderRepository) Add(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+func (m *MockOrderRepository) Update(_ context.Context, _ *order.Order) error { return nil }
+func (m *MockOrderRepository) Get(_ context.Context, _ kernel.UUID) (*order.Order, error) {
+	return nil, errors.New("not implemented in mock")
+}
+func (m *MockOrderRepository) GetFirstInCreatedStatus(_ context.Context) (*order.Order, error) {
+	return nil, errors.New("not implemented in mock")
+}
+func (m *MockOrderRepository) GetAllInAssignedStatus(_ context.Context) ([]*order.Order, error) {
+	return nil, errors.New("not implemented in mock")
+}
+
+type MockOrderUoW struct{ mock.Mock }
+
+func (m *MockOrderUoW) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+func (m *MockOrderUoW) Commit(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+func (m *MockOrderUoW) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockOrderUoW) OrderRepository() ports.OrderRepository {
+	args := m.Called()
+	return args.Get(0).(ports.OrderRepository)
+}
+
+type MockOrderUoWFactory struct{ mock.Mock }
+
+func (m *MockOrderUoWFactory) Create() commands.OrderUoW {
+	args := m.Called()
+	return args.Get(0).(commands.OrderUoW)
+}
+
+func TestCreateOrderCommandHandler_Handle_Success(t *testing.T) {
+	ctx := t.Context()
+	id := kernel.NewUUID()
+	cmd, _ := commands.NewCreateOrderCommand(id, "Main St", 10)
+
+	repo := new(MockOrderRepository)
+	uow := new(MockOrderUoW)
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("OrderRepository").Return(repo).Once(),
+		repo.On("Add", mock.Anything, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockOrderUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	h := commands.NewCreateOrderCommandHandler(factory)
+	err := h.Handle(ctx, cmd)
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	factory.AssertExpectations(t)
+}
+
+func TestCreateOrderCommandHandler_Handle_ValidationError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.CreateOrderCommand{} // not constructed properly
+	factory := new(MockOrderUoWFactory)
+	h := commands.NewCreateOrderCommandHandler(factory)
+	err := h.Handle(ctx, cmd)
+	require.Error(t, err)
+}
+
+func TestCreateOrderCommandHandler_Handle_BeginError(t *testing.T) {
+	ctx := t.Context()
+	id := kernel.NewUUID()
+	cmd, _ := commands.NewCreateOrderCommand(id, "Main St", 10)
+
+	uow := new(MockOrderUoW)
+	factory := new(MockOrderUoWFactory)
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(errors.New("begin error")).Once(),
+	)
+
+	h := commands.NewCreateOrderCommandHandler(factory)
+	err := h.Handle(ctx, cmd)
+	require.Error(t, err)
+}
+
+func TestCreateOrderCommandHandler_Handle_AddError(t *testing.T) {
+	ctx := t.Context()
+	id := kernel.NewUUID()
+	cmd, _ := commands.NewCreateOrderCommand(id, "Main St", 10)
+
+	repo := new(MockOrderRepository)
+	uow := new(MockOrderUoW)
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("OrderRepository").Return(repo).Once(),
+		repo.On("Add", mock.Anything, mock.AnythingOfType("*order.Order")).Return(errors.New("add error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockOrderUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	h := commands.NewCreateOrderCommandHandler(factory)
+	err := h.Handle(ctx, cmd)
+	require.Error(t, err)
+	repo.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	factory.AssertExpectations(t)
+}
+
+func TestCreateOrderCommandHandler_Handle_CommitError(t *testing.T) {
+	ctx := t.Context()
+	id := kernel.NewUUID()
+	cmd, _ := commands.NewCreateOrderCommand(id, "Main St", 10)
+
+	repo := new(MockOrderRepository)
+	uow := new(MockOrderUoW)
+	mock.InOrder(
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("OrderRepository").Return(repo).Once(),
+		repo.On("Add", mock.Anything, mock.AnythingOfType("*order.Order")).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(errors.New("commit error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	factory := new(MockOrderUoWFactory)
+	factory.On("Create").Return(uow).Once()
+
+	h := commands.NewCreateOrderCommandHandler(factory)
+	err := h.Handle(ctx, cmd)
+	require.Error(t, err)
+	repo.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	factory.AssertExpectations(t)
+}

--- a/internal/core/application/usecases/commands/create_order_command_test.go
+++ b/internal/core/application/usecases/commands/create_order_command_test.go
@@ -1,0 +1,47 @@
+package commands_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCreateOrderCommand_ValidInput(t *testing.T) {
+	id := kernel.NewUUID()
+	cmd, err := commands.NewCreateOrderCommand(id, "Main St", 10)
+	require.NoError(t, err)
+	assert.Equal(t, id, cmd.OrderID())
+	assert.Equal(t, "Main St", cmd.Street())
+	assert.Equal(t, 10, cmd.Volume())
+}
+
+func TestNewCreateOrderCommand_InvalidInput(t *testing.T) {
+	id := kernel.NewUUID()
+	_, err := commands.NewCreateOrderCommand(id, "", 0)
+	require.Error(t, err)
+}
+
+func TestNewCreateOrderCommand_InvalidOrderID(t *testing.T) {
+	invalidID := kernel.UUID{} // zero value, should trigger validation error
+	_, err := commands.NewCreateOrderCommand(invalidID, "Main St", 10)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, kernel.ErrUUIDIsNotConstructed)
+}
+
+func TestNewCreateOrderCommand_EmptyStreet(t *testing.T) {
+	id := kernel.NewUUID()
+	_, err := commands.NewCreateOrderCommand(id, "", 10)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, commands.ErrStreetIsRequired)
+}
+
+func TestNewCreateOrderCommand_InvalidVolume(t *testing.T) {
+	id := kernel.NewUUID()
+	_, err := commands.NewCreateOrderCommand(id, "Main St", 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, commands.ErrVolumeIsInvalid)
+}

--- a/internal/core/application/usecases/commands/move_couriers_command.go
+++ b/internal/core/application/usecases/commands/move_couriers_command.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+
+	"delivery/internal/pkg/guard"
+)
+
+// MoveCouriersCommand triggers movement of all assigned couriers towards their destinations.
+// This batch operation updates courier positions and completes orders when destinations are reached.
+//
+// Example:
+//
+//	cmd := NewMoveCouriersCommand()
+//	handler := NewMoveCouriersCommandHandler(uowFactory)
+//
+//	// Run periodically to simulate courier movement
+//	ticker := time.NewTicker(5 * time.Second)
+//	for range ticker.C {
+//	    if err := handler.Handle(ctx, cmd); err != nil {
+//	        log.Printf("Movement update failed: %v", err)
+//	    }
+//	}
+type MoveCouriersCommand struct {
+	guard guard.ConstructorGuard
+}
+
+var (
+	ErrMoveCouriersCommandIsNotConstructed = errors.New(
+		"MoveCouriersCommand must be created via NewMoveCouriersCommand constructor",
+	)
+)
+
+// NewMoveCouriersCommand creates a command to trigger courier movement updates.
+// This is a parameterless command that processes all active deliveries.
+func NewMoveCouriersCommand() MoveCouriersCommand {
+	command := MoveCouriersCommand{
+		guard: guard.NewConstructorGuard(),
+	}
+
+	return command
+}
+
+// Validate ensures the command was created through the constructor.
+// Returns ErrMoveCouriersCommandIsNotConstructed if validation fails.
+func (c *MoveCouriersCommand) Validate() error {
+	return c.guard.Validate(ErrMoveCouriersCommandIsNotConstructed)
+}

--- a/internal/core/application/usecases/commands/move_couriers_command_handler.go
+++ b/internal/core/application/usecases/commands/move_couriers_command_handler.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"context"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/order"
+)
+
+// MoveCouriersCommandHandler orchestrates the movement of all active couriers.
+// Processes each assigned order, moves couriers towards destinations, and completes
+// deliveries when couriers reach their targets.
+//
+// Example:
+//
+//	handler := NewMoveCouriersCommandHandler(uowFactory)
+//	cmd := NewMoveCouriersCommand()
+//
+//	// Execute movement update
+//	if err := handler.Handle(ctx, cmd); err != nil {
+//	    return fmt.Errorf("courier movement failed: %w", err)
+//	}
+//
+//	// This would typically be called periodically by a scheduler
+type MoveCouriersCommandHandler struct {
+	uowFactory UoWFactory
+}
+
+// NewMoveCouriersCommandHandler creates a handler for courier movement operations.
+// Requires a UoWFactory for coordinating updates across order and courier repositories.
+func NewMoveCouriersCommandHandler(uowFactory UoWFactory) MoveCouriersCommandHandler {
+	return MoveCouriersCommandHandler{
+		uowFactory: uowFactory,
+	}
+}
+
+// Handle processes the courier movement command.
+// Retrieves all orders in "assigned" status, moves each courier towards its destination,
+// and completes orders when couriers arrive. All updates occur within a single transaction.
+func (h *MoveCouriersCommandHandler) Handle(ctx context.Context, cmd MoveCouriersCommand) error {
+	if err := cmd.Validate(); err != nil {
+		return err
+	}
+
+	uow := h.uowFactory.Create()
+	if err := uow.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = uow.Rollback(ctx)
+	}()
+
+	courierRepo := uow.CourierRepository()
+	ordersRepo := uow.OrderRepository()
+
+	orders, err := ordersRepo.GetAllInAssignedStatus(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, order := range orders {
+		courier, courierErr := courierRepo.Get(ctx, *order.Courier())
+		if courierErr != nil {
+			return courierErr
+		}
+
+		if err = h.moveOrderCourier(order, courier); err != nil {
+			return err
+		}
+
+		if err = ordersRepo.Update(ctx, order); err != nil {
+			return err
+		}
+
+		if err = courierRepo.Update(ctx, courier); err != nil {
+			return err
+		}
+	}
+
+	if err = uow.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// moveOrderCourier handles the movement logic for a single courier-order pair.
+// Moves the courier towards the order location and completes both order and courier
+// states when the destination is reached.
+func (h *MoveCouriersCommandHandler) moveOrderCourier(
+	order *order.Order,
+	courier *courier.Courier,
+) error {
+	if err := courier.Move(order.Location()); err != nil {
+		return err
+	}
+
+	if equal, err := courier.Location().IsEqual(order.Location()); err != nil || !equal {
+		return err
+	}
+
+	if err := order.Complete(); err != nil {
+		return err
+	}
+
+	if err := courier.CompleteOrder(order.ID()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/core/application/usecases/commands/move_couriers_command_handler_test.go
+++ b/internal/core/application/usecases/commands/move_couriers_command_handler_test.go
@@ -1,0 +1,731 @@
+package commands_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+	"delivery/internal/core/ports"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type MoveCourierRepo struct{ mock.Mock }
+
+func (m *MoveCourierRepo) Add(ctx context.Context, c *courier.Courier) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MoveCourierRepo) Update(ctx context.Context, c *courier.Courier) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *MoveCourierRepo) Get(ctx context.Context, id kernel.UUID) (*courier.Courier, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*courier.Courier), args.Error(1)
+}
+
+func (m *MoveCourierRepo) GetAllFree(ctx context.Context) ([]*courier.Courier, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*courier.Courier), args.Error(1)
+}
+
+type MoveOrderRepo struct{ mock.Mock }
+
+func (m *MoveOrderRepo) Add(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+
+func (m *MoveOrderRepo) Update(ctx context.Context, o *order.Order) error {
+	args := m.Called(ctx, o)
+	return args.Error(0)
+}
+
+func (m *MoveOrderRepo) Get(ctx context.Context, id kernel.UUID) (*order.Order, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MoveOrderRepo) GetFirstInCreatedStatus(ctx context.Context) (*order.Order, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*order.Order), args.Error(1)
+}
+
+func (m *MoveOrderRepo) GetAllInAssignedStatus(ctx context.Context) ([]*order.Order, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*order.Order), args.Error(1)
+}
+
+type MoveUnitOfWork struct{ mock.Mock }
+
+func (m *MoveUnitOfWork) Begin(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MoveUnitOfWork) Commit(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MoveUnitOfWork) Rollback(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MoveUnitOfWork) CourierRepository() ports.CourierRepository {
+	args := m.Called()
+	return args.Get(0).(ports.CourierRepository)
+}
+
+func (m *MoveUnitOfWork) OrderRepository() ports.OrderRepository {
+	args := m.Called()
+	return args.Get(0).(ports.OrderRepository)
+}
+
+type MoveUoWFactory struct{ mock.Mock }
+
+func (m *MoveUoWFactory) Create() commands.UoW {
+	args := m.Called()
+	return args.Get(0).(commands.UoW)
+}
+
+func createTestOrderWithCourier(
+	courierID kernel.UUID,
+	orderLocation kernel.Location,
+	courierLocation kernel.Location,
+) (*order.Order, *courier.Courier, error) {
+	// Create order
+	orderID := kernel.NewUUID()
+	testOrder, err := order.NewOrder(orderID, orderLocation, 5)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Assign courier to order
+	err = testOrder.Assign(courierID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create courier
+	testCourier, err := courier.NewCourier(courierID, "Test Courier", 2, courierLocation)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return testOrder, testCourier, nil
+}
+
+func TestMoveCouriersCommandHandler_Handle_Success(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(5, 5)
+	courierLocation, _ := kernel.NewLocation(3, 3)
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// Ensure courier has the order in storage for successful completion
+	err = testCourier.TakeOrder(testOrder)
+	require.NoError(t, err)
+
+	// Set up mocks
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	// Act
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	// Assert
+	require.NoError(t, err)
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_ValidationError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.MoveCouriersCommand{} // not constructed properly
+	factory := new(MoveUoWFactory)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be created via NewMoveCouriersCommand constructor")
+}
+
+func TestMoveCouriersCommandHandler_Handle_BeginError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(errors.New("begin error")).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "begin error")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_GetAllInAssignedStatusError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return(nil, errors.New("repository error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository error")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_GetCourierError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(5, 5)
+	courierLocation, _ := kernel.NewLocation(3, 3)
+	testOrder, _, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(nil, errors.New("courier not found")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "courier not found")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_CourierCompleteOrderError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data - courier reaches order location but doesn't have the order in storage
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(2, 2)
+	courierLocation, _ := kernel.NewLocation(2, 2) // Same location
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage place not found")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_OrderUpdateError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(2, 2)
+	courierLocation, _ := kernel.NewLocation(2, 2) // Same location
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// We need to ensure the courier has the order in storage for the test to work properly
+	err = testCourier.TakeOrder(testOrder)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder).Return(errors.New("order update error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "order update error")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_CourierUpdateError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(2, 2)
+	courierLocation, _ := kernel.NewLocation(2, 2) // Same location
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// We need to ensure the courier has the order in storage for the test to work properly
+	err = testCourier.TakeOrder(testOrder)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier).Return(errors.New("courier update error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "courier update error")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_CommitError(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(2, 2)
+	courierLocation, _ := kernel.NewLocation(2, 2)
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// We need to ensure the courier has the order in storage for the test to work properly
+	err = testCourier.TakeOrder(testOrder)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(errors.New("commit error")).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "commit error")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_NoOrdersAssigned(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{}, nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err := handler.Handle(ctx, cmd)
+
+	require.NoError(t, err)
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_MultipleOrders(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data for multiple orders
+	courierID1 := kernel.NewUUID()
+	courierID2 := kernel.NewUUID()
+	orderLocation1, _ := kernel.NewLocation(1, 1)
+	orderLocation2, _ := kernel.NewLocation(2, 2)
+	courierLocation1, _ := kernel.NewLocation(1, 1)
+	courierLocation2, _ := kernel.NewLocation(2, 2)
+
+	testOrder1, testCourier1, err := createTestOrderWithCourier(courierID1, orderLocation1, courierLocation1)
+	require.NoError(t, err)
+	testOrder2, testCourier2, err := createTestOrderWithCourier(courierID2, orderLocation2, courierLocation2)
+	require.NoError(t, err)
+
+	// Ensure couriers have the orders in their storage for successful completion
+	err = testCourier1.TakeOrder(testOrder1)
+	require.NoError(t, err)
+	err = testCourier2.TakeOrder(testOrder2)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder1, testOrder2}, nil).Once(),
+		// First order processing
+		courierRepo.On("Get", ctx, courierID1).Return(testCourier1, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder1).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier1).Return(nil).Once(),
+		// Second order processing
+		courierRepo.On("Get", ctx, courierID2).Return(testCourier2, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder2).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier2).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.NoError(t, err)
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}
+
+func TestMoveCouriersCommandHandler_Handle_CourierMovesOneStepTowardDestination(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Create test data where courier needs more than one step to reach destination
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(10, 10) // Order at (10, 10)
+	courierLocation, _ := kernel.NewLocation(5, 5) // Courier starts at (5, 5)
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// Courier speed is 2 (from createTestOrderWithCourier), so it can only move 2 steps
+	// Distance from (5,5) to (10,10) is 10 steps, so courier won't reach destination
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		// Courier moves but doesn't reach destination - this is allowed and successful
+		orderRepo.On("Update", ctx, testOrder).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	// Should succeed - courier moved but didn't reach destination (partial movement is allowed)
+	require.NoError(t, err)
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+
+	// Verify courier moved in the right direction but didn't reach destination
+	expectedLocation, _ := kernel.NewLocation(7, 5) // Moved 2 steps horizontally (X-axis priority)
+	actualLocation := testCourier.Location()
+	isEqual, _ := actualLocation.IsEqual(expectedLocation)
+	assert.True(t, isEqual, "Courier should have moved 2 steps toward destination")
+}
+
+func TestMoveCouriersCommandHandler_Handle_CourierMovesPartiallyMultipleSteps(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Test case where courier moves partially in both X and Y directions
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(8, 7)   // Order at (8, 7)
+	courierLocation, _ := kernel.NewLocation(5, 5) // Courier starts at (5, 5)
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// Distance is 3 (X) + 2 (Y) = 5 steps total
+	// Courier speed is 2, so it will move 2 steps toward destination (prioritizing X-axis)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		// Courier moves but doesn't reach destination - this is allowed and successful
+		orderRepo.On("Update", ctx, testOrder).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.NoError(t, err) // Should succeed - courier moved but didn't reach destination
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+
+	// Verify courier moved 2 steps horizontally (X-axis priority)
+	expectedLocation, _ := kernel.NewLocation(7, 5) // Moved 2 steps in X direction
+	actualLocation := testCourier.Location()
+	isEqual, _ := actualLocation.IsEqual(expectedLocation)
+	assert.True(t, isEqual, "Courier should have moved 2 steps horizontally (X-axis priority)")
+}
+
+func TestMoveCouriersCommandHandler_Handle_CourierMovesExactlyToDestinationButHasNoOrder(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Test case where courier reaches destination in one step but doesn't have the order in storage
+	courierID := kernel.NewUUID()
+	orderLocation, _ := kernel.NewLocation(7, 5)   // Order at (7, 5)
+	courierLocation, _ := kernel.NewLocation(5, 5) // Courier starts at (5, 5)
+	testOrder, testCourier, err := createTestOrderWithCourier(courierID, orderLocation, courierLocation)
+	require.NoError(t, err)
+
+	// Distance is 2 steps, courier speed is 2, so courier will reach destination
+	// But courier doesn't have the order in storage, so completion should fail
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder}, nil).Once(),
+		courierRepo.On("Get", ctx, courierID).Return(testCourier, nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "storage place not found")
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+
+	// Verify courier reached the destination
+	actualLocation := testCourier.Location()
+	isEqual, _ := actualLocation.IsEqual(orderLocation)
+	assert.True(t, isEqual, "Courier should have reached the order location")
+}
+
+func TestMoveCouriersCommandHandler_Handle_MultipleOrdersPartialMovement(t *testing.T) {
+	ctx := t.Context()
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Test case with multiple orders where couriers make partial movement
+	courierID1 := kernel.NewUUID()
+	courierID2 := kernel.NewUUID()
+	orderLocation1, _ := kernel.NewLocation(10, 10) // Far destination
+	orderLocation2, _ := kernel.NewLocation(3, 3)   // Close destination
+	courierLocation1, _ := kernel.NewLocation(5, 5) // Far from destination
+	courierLocation2, _ := kernel.NewLocation(2, 2) // Close to destination
+
+	testOrder1, testCourier1, err := createTestOrderWithCourier(courierID1, orderLocation1, courierLocation1)
+	require.NoError(t, err)
+	testOrder2, testCourier2, err := createTestOrderWithCourier(courierID2, orderLocation2, courierLocation2)
+	require.NoError(t, err)
+
+	// Courier 2 has the order in storage and will complete it
+	err = testCourier2.TakeOrder(testOrder2)
+	require.NoError(t, err)
+
+	courierRepo := new(MoveCourierRepo)
+	orderRepo := new(MoveOrderRepo)
+	uow := new(MoveUnitOfWork)
+	factory := new(MoveUoWFactory)
+
+	mock.InOrder(
+		factory.On("Create").Return(uow).Once(),
+		uow.On("Begin", ctx).Return(nil).Once(),
+		uow.On("CourierRepository").Return(courierRepo).Once(),
+		uow.On("OrderRepository").Return(orderRepo).Once(),
+		orderRepo.On("GetAllInAssignedStatus", ctx).Return([]*order.Order{testOrder1, testOrder2}, nil).Once(),
+		// First courier - moves but doesn't reach destination (partial movement is allowed)
+		courierRepo.On("Get", ctx, courierID1).Return(testCourier1, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder1).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier1).Return(nil).Once(),
+		// Second courier - reaches destination and completes order
+		courierRepo.On("Get", ctx, courierID2).Return(testCourier2, nil).Once(),
+		orderRepo.On("Update", ctx, testOrder2).Return(nil).Once(),
+		courierRepo.On("Update", ctx, testCourier2).Return(nil).Once(),
+		uow.On("Commit", ctx).Return(nil).Once(),
+		uow.On("Rollback", ctx).Return(nil).Once(),
+	)
+
+	handler := commands.NewMoveCouriersCommandHandler(factory)
+	err = handler.Handle(ctx, cmd)
+
+	require.NoError(t, err) // Should succeed - both couriers processed successfully
+	factory.AssertExpectations(t)
+	uow.AssertExpectations(t)
+	orderRepo.AssertExpectations(t)
+	courierRepo.AssertExpectations(t)
+}

--- a/internal/core/application/usecases/commands/move_couriers_command_test.go
+++ b/internal/core/application/usecases/commands/move_couriers_command_test.go
@@ -1,0 +1,33 @@
+package commands_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/commands"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMoveCouriersCommand_Validate_WhenConstructedProperly_ShouldReturnNoError(t *testing.T) {
+	// Arrange
+	cmd := commands.NewMoveCouriersCommand()
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.NoError(t, err)
+}
+
+func TestMoveCouriersCommand_Validate_WhenNotConstructed_ShouldReturnError(t *testing.T) {
+	// Arrange
+	var cmd commands.MoveCouriersCommand // zero-value command
+
+	// Act
+	err := cmd.Validate()
+
+	// Assert
+	require.Error(t, err)
+	assert.Equal(t, commands.ErrMoveCouriersCommandIsNotConstructed, err)
+}

--- a/internal/core/application/usecases/commands/repositories.go
+++ b/internal/core/application/usecases/commands/repositories.go
@@ -1,0 +1,80 @@
+// Package commands contains business operations that modify system state.
+// Implements the Command pattern for write operations in the CQRS architecture.
+// All commands follow a consistent pattern: validation, transaction management, and persistence.
+package commands
+
+import (
+	"context"
+
+	"delivery/internal/core/ports"
+)
+
+// Unit of Work interfaces provide transaction management for command handlers.
+// These abstractions ensure data consistency across aggregate boundaries.
+type (
+	// TxManager handles database transaction lifecycle.
+	// Ensures atomic operations across multiple repository calls.
+	TxManager interface {
+		Begin(ctx context.Context) error
+		Commit(ctx context.Context) error
+		Rollback(ctx context.Context) error
+	}
+
+	// OrderRepoFactory provides access to order repository within a transaction.
+	OrderRepoFactory interface {
+		OrderRepository() ports.OrderRepository
+	}
+
+	// CourierRepoFactory provides access to courier repository within a transaction.
+	CourierRepoFactory interface {
+		CourierRepository() ports.CourierRepository
+	}
+
+	// OrderUoW manages transactions for order-only operations.
+	// Used when commands only modify order aggregates.
+	OrderUoW interface {
+		TxManager
+		OrderRepoFactory
+	}
+
+	// OrderUoWFactory creates new order unit of work instances.
+	OrderUoWFactory interface {
+		Create() OrderUoW
+	}
+
+	// CourierUoW manages transactions for courier-only operations.
+	// Used when commands only modify courier aggregates.
+	CourierUoW interface {
+		TxManager
+		CourierRepoFactory
+	}
+
+	// CourierUoWFactory creates new courier unit of work instances.
+	CourierUoWFactory interface {
+		Create() CourierUoW
+	}
+
+	// UoW manages transactions across both order and courier aggregates.
+	// Used for commands that coordinate changes between multiple aggregate types.
+	//
+	// Example:
+	//   uow := factory.Create()
+	//   err := uow.Begin(ctx)
+	//   defer uow.Rollback(ctx)
+	//
+	//   orderRepo := uow.OrderRepository()
+	//   courierRepo := uow.CourierRepository()
+	//   // ... perform operations
+	//
+	//   err = uow.Commit(ctx)
+	UoW interface {
+		TxManager
+		CourierRepoFactory
+		OrderRepoFactory
+	}
+
+	// UoWFactory creates new unit of work instances for cross-aggregate operations.
+	UoWFactory interface {
+		Create() UoW
+	}
+)

--- a/internal/core/application/usecases/queries/get_all_couriers_query.go
+++ b/internal/core/application/usecases/queries/get_all_couriers_query.go
@@ -1,0 +1,66 @@
+// Package queries contains read operations for retrieving system state.
+// Implements the Query pattern for read operations in the CQRS architecture.
+// Queries return optimized read models for specific use cases.
+package queries
+
+import (
+	"errors"
+
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/pkg/guard"
+)
+
+var (
+	ErrGetAllCouriersQueryIsNotConstructed = errors.New(
+		"GetAllCouriersQuery must be created via NewGetAllCouriersQuery constructor",
+	)
+)
+
+// GetAllCouriersQuery retrieves information about all couriers in the system.
+// Returns courier identities and current locations for monitoring and dispatching.
+//
+// Example:
+//
+//	query := NewGetAllCouriersQuery()
+//	handler := NewGetAllCouriersQueryHandler(db)
+//
+//	couriers, err := handler.Handle(ctx, query)
+//	if err != nil {
+//	    return fmt.Errorf("failed to retrieve couriers: %w", err)
+//	}
+//
+//	for _, courier := range couriers {
+//	    fmt.Printf("Courier %s at location (%.2f, %.2f)\n",
+//	        courier.Name, courier.Location.X(), courier.Location.Y())
+//	}
+type GetAllCouriersQuery struct {
+	guard guard.ConstructorGuard
+}
+
+// NewGetAllCouriersQuery creates a query to retrieve all couriers.
+// This is a parameterless query that fetches the complete courier list.
+func NewGetAllCouriersQuery() GetAllCouriersQuery {
+	return GetAllCouriersQuery{guard: guard.NewConstructorGuard()}
+}
+
+// Validate ensures the query was created through the constructor.
+// Returns ErrGetAllCouriersQueryIsNotConstructed if validation fails.
+func (q GetAllCouriersQuery) Validate() error {
+	return q.guard.Validate(ErrGetAllCouriersQueryIsNotConstructed)
+}
+
+// GetAllCouriersQueryResponse represents courier information in the read model.
+// Contains essential courier data for display and decision-making.
+//
+// Example:
+//
+//	response := GetAllCouriersQueryResponse{
+//	    ID:       kernel.MustNewUUID("550e8400-e29b-41d4-a716-446655440000"),
+//	    Name:     "Express Courier",
+//	    Location: kernel.NewLocation(55.7558, 37.6173),
+//	}
+type GetAllCouriersQueryResponse struct {
+	ID       kernel.UUID
+	Name     string
+	Location kernel.Location
+}

--- a/internal/core/application/usecases/queries/get_all_couriers_query_handler.go
+++ b/internal/core/application/usecases/queries/get_all_couriers_query_handler.go
@@ -1,0 +1,101 @@
+package queries
+
+import (
+	"context"
+
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GetAllCouriersQueryHandler retrieves all courier information from the database.
+// Uses direct SQL queries for optimal read performance in the CQRS pattern.
+//
+// Example:
+//
+//	handler := NewGetAllCouriersQueryHandler(db)
+//	query := NewGetAllCouriersQuery()
+//
+//	couriers, err := handler.Handle(ctx, query)
+//	if err != nil {
+//	    log.Printf("Failed to get couriers: %v", err)
+//	    return err
+//	}
+//
+//	fmt.Printf("Found %d couriers\n", len(couriers))
+type GetAllCouriersQueryHandler struct {
+	db *gorm.DB
+}
+
+// NewGetAllCouriersQueryHandler creates a handler for courier retrieval queries.
+// Requires a GORM database connection for query execution.
+func NewGetAllCouriersQueryHandler(db *gorm.DB) GetAllCouriersQueryHandler {
+	return GetAllCouriersQueryHandler{db: db}
+}
+
+// Handle executes the query to retrieve all couriers.
+// Returns a slice of courier read models sorted by name.
+// Converts database types to domain types for consistency.
+func (h GetAllCouriersQueryHandler) Handle(
+	ctx context.Context,
+	query GetAllCouriersQuery,
+) ([]GetAllCouriersQueryResponse, error) {
+	if err := query.Validate(); err != nil {
+		return nil, err
+	}
+
+	couriers := make([]GetAllCouriersQueryResponse, 0)
+
+	rows, err := h.db.WithContext(ctx).Raw(`
+		SELECT 
+			id, 
+			name, 
+			location_x, 
+			location_y 
+		FROM couriers
+		ORDER BY name
+	`).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var courier GetAllCouriersQueryResponse
+		var locationX, locationY int8
+		var id uuid.UUID
+
+		err = rows.Scan(
+			&id,
+			&courier.Name,
+			&locationX,
+			&locationY,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		courierID, idErr := kernel.UUIDFromBytes(id[:])
+		if idErr != nil {
+			return nil, idErr
+		}
+		courier.ID = courierID
+
+		location, locErr := kernel.NewLocation(
+			kernel.Coordinate(locationX),
+			kernel.Coordinate(locationY),
+		)
+		if locErr != nil {
+			return nil, locErr
+		}
+		courier.Location = location
+		couriers = append(couriers, courier)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return couriers, nil
+}

--- a/internal/core/application/usecases/queries/get_all_couriers_query_handler_test.go
+++ b/internal/core/application/usecases/queries/get_all_couriers_query_handler_test.go
@@ -1,0 +1,243 @@
+package queries_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"delivery/internal/adapters/out/postgres/courierrepo"
+	"delivery/internal/core/application/usecases/queries"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	gorm_postgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type GetAllCouriersQueryHandlerTestSuite struct {
+	suite.Suite
+	container *postgres.PostgresContainer
+	db        *gorm.DB
+	handler   queries.GetAllCouriersQueryHandler
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) SetupSuite() {
+	ctx := context.Background()
+
+	container, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	suite.Require().NoError(err)
+	suite.container = container
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	suite.Require().NoError(err)
+
+	db, err := gorm.Open(gorm_postgres.Open(dsn), &gorm.Config{})
+	suite.Require().NoError(err)
+	suite.db = db
+
+	err = db.AutoMigrate(&courierrepo.CourierDTO{}, &courierrepo.StoragePlaceDTO{})
+	suite.Require().NoError(err)
+
+	suite.handler = queries.NewGetAllCouriersQueryHandler(db)
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		err := suite.container.Terminate(context.Background())
+		suite.Require().NoError(err)
+	}
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) SetupTest() {
+	err := suite.db.Exec("TRUNCATE TABLE couriers CASCADE").Error
+	suite.Require().NoError(err)
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TestHandle_EmptyDatabase_ReturnsEmptySlice() {
+	query := queries.NewGetAllCouriersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.NotNil(result)
+	suite.Empty(result)
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TestHandle_WithCouriers_ReturnsAllCouriersOrderedByName() {
+	couriers := suite.createTestCouriers()
+	suite.saveCouriers(couriers)
+
+	query := queries.NewGetAllCouriersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.Len(result, 3)
+
+	suite.Equal("Alice", result[0].Name)
+	suite.Equal(couriers[0].ID(), result[0].ID)
+	isEqual, err := couriers[0].Location().IsEqual(result[0].Location)
+	suite.Require().NoError(err)
+	suite.True(isEqual)
+
+	suite.Equal("Bob", result[1].Name)
+	suite.Equal(couriers[1].ID(), result[1].ID)
+	isEqual, err = couriers[1].Location().IsEqual(result[1].Location)
+	suite.Require().NoError(err)
+	suite.True(isEqual)
+
+	suite.Equal("Charlie", result[2].Name)
+	suite.Equal(couriers[2].ID(), result[2].ID)
+	isEqual, err = couriers[2].Location().IsEqual(result[2].Location)
+	suite.Require().NoError(err)
+	suite.True(isEqual)
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TestHandle_InvalidQuery_ReturnsError() {
+	invalidQuery := queries.GetAllCouriersQuery{}
+
+	result, err := suite.handler.Handle(context.Background(), invalidQuery)
+
+	suite.Require().Error(err)
+	suite.Nil(result)
+	suite.Contains(err.Error(), "must be created via NewGetAllCouriersQuery constructor")
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TestHandle_ContextCancellation_ReturnsError() {
+	suite.createAndSaveLargeCourierSet()
+
+	query := queries.NewGetAllCouriersQuery()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := suite.handler.Handle(ctx, query)
+
+	suite.Require().Error(err)
+	suite.Nil(result)
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) TestHandle_VariousLocations_CorrectlyMapsCoordinates() {
+	testCases := []struct {
+		name string
+		x    kernel.Coordinate
+		y    kernel.Coordinate
+	}{
+		{"Courier at Origin", 1, 1},
+		{"Courier at Max", 10, 10},
+		{"Courier at Center", 5, 5},
+		{"Courier at Mixed", 3, 8},
+	}
+
+	for _, tc := range testCases {
+		location, err := kernel.NewLocation(tc.x, tc.y)
+		suite.Require().NoError(err)
+
+		courier, err := courier.NewCourier(
+			kernel.NewUUID(),
+			tc.name,
+			3,
+			location,
+		)
+		suite.Require().NoError(err)
+
+		repo := courierrepo.NewGormCourierRepository(suite.db, &mockAggregateTracker{})
+		err = repo.Add(context.Background(), courier)
+		suite.Require().NoError(err)
+	}
+
+	query := queries.NewGetAllCouriersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.Len(result, len(testCases))
+
+	resultMap := make(map[string]queries.GetAllCouriersQueryResponse)
+	for _, r := range result {
+		resultMap[r.Name] = r
+	}
+
+	for _, tc := range testCases {
+		courier, exists := resultMap[tc.name]
+		suite.True(exists, "Courier %s not found", tc.name)
+		suite.Equal(tc.x, courier.Location.X())
+		suite.Equal(tc.y, courier.Location.Y())
+	}
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) createTestCouriers() []*courier.Courier {
+	couriers := make([]*courier.Courier, 0)
+
+	location1, _ := kernel.NewLocation(3, 4)
+	courier1, _ := courier.NewCourier(kernel.NewUUID(), "Alice", 3, location1)
+	courier1.AddStoragePlace("Backpack", 15)
+	couriers = append(couriers, courier1)
+
+	location2, _ := kernel.NewLocation(7, 2)
+	courier2, _ := courier.NewCourier(kernel.NewUUID(), "Bob", 5, location2)
+	courier2.AddStoragePlace("Large Box", 25)
+	courier2.AddStoragePlace("Side Bag", 10)
+	couriers = append(couriers, courier2)
+
+	location3, _ := kernel.NewLocation(10, 10)
+	courier3, _ := courier.NewCourier(kernel.NewUUID(), "Charlie", 2, location3)
+	courier3.AddStoragePlace("Small Bag", 8)
+	couriers = append(couriers, courier3)
+
+	return couriers
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) saveCouriers(couriers []*courier.Courier) {
+	repo := courierrepo.NewGormCourierRepository(suite.db, &mockAggregateTracker{})
+	for _, c := range couriers {
+		err := repo.Add(context.Background(), c)
+		suite.Require().NoError(err)
+	}
+}
+
+func (suite *GetAllCouriersQueryHandlerTestSuite) createAndSaveLargeCourierSet() {
+	repo := courierrepo.NewGormCourierRepository(suite.db, &mockAggregateTracker{})
+	for i := range 50 {
+		location, _ := kernel.NewRandomLocation()
+		courier, _ := courier.NewCourier(
+			kernel.NewUUID(),
+			"Courier",
+			3,
+			location,
+		)
+		err := repo.Add(context.Background(), courier)
+		suite.Require().NoError(err)
+		_ = i
+	}
+}
+
+func TestGetAllCouriersQueryHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(GetAllCouriersQueryHandlerTestSuite))
+}
+
+// mockAggregateTracker implements ports.AggregateTracker for test purposes.
+// It's a no-op implementation since we don't need aggregate tracking in query tests.
+type mockAggregateTracker struct{}
+
+func (m *mockAggregateTracker) TrackAggregate(_ kernel.UUID, _ any) {
+	// No-op for query tests
+}
+
+func (m *mockAggregateTracker) GetTrackedAggregates() []any {
+	return []any{}
+}

--- a/internal/core/application/usecases/queries/get_all_couriers_query_test.go
+++ b/internal/core/application/usecases/queries/get_all_couriers_query_test.go
@@ -1,0 +1,23 @@
+package queries_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/queries"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGetAllCouriersQuery_Valid(t *testing.T) {
+	query := queries.NewGetAllCouriersQuery()
+	err := query.Validate()
+	require.NoError(t, err)
+}
+
+func TestGetAllCouriersQuery_NotConstructedViaConstructor(t *testing.T) {
+	query := queries.GetAllCouriersQuery{}
+	err := query.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, queries.ErrGetAllCouriersQueryIsNotConstructed)
+}

--- a/internal/core/application/usecases/queries/get_uncompleted_orders_query.go
+++ b/internal/core/application/usecases/queries/get_uncompleted_orders_query.go
@@ -1,0 +1,62 @@
+package queries
+
+import (
+	"errors"
+
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/pkg/guard"
+)
+
+var (
+	ErrGetUncompletedOrdersQueryIsNotConstructed = errors.New(
+		"GetUncompletedOrdersQuery must be created via NewGetUncompletedOrdersQuery constructor",
+	)
+)
+
+// GetUncompletedOrdersQuery retrieves all orders pending delivery.
+// Returns orders in "created" or "assigned" status for monitoring and management.
+//
+// Example:
+//
+//	query := NewGetUncompletedOrdersQuery()
+//	handler := NewGetUncompletedOrdersQueryHandler(db)
+//
+//	orders, err := handler.Handle(ctx, query)
+//	if err != nil {
+//	    return fmt.Errorf("failed to get pending orders: %w", err)
+//	}
+//
+//	fmt.Printf("Found %d orders awaiting delivery\n", len(orders))
+//	for _, order := range orders {
+//	    fmt.Printf("Order %s at (%.2f, %.2f)\n",
+//	        order.ID, order.Location.X(), order.Location.Y())
+//	}
+type GetUncompletedOrdersQuery struct {
+	guard guard.ConstructorGuard
+}
+
+// NewGetUncompletedOrdersQuery creates a query to retrieve pending orders.
+// This is a parameterless query that fetches all non-completed orders.
+func NewGetUncompletedOrdersQuery() GetUncompletedOrdersQuery {
+	return GetUncompletedOrdersQuery{guard: guard.NewConstructorGuard()}
+}
+
+// Validate ensures the query was created through the constructor.
+// Returns ErrGetUncompletedOrdersQueryIsNotConstructed if validation fails.
+func (q GetUncompletedOrdersQuery) Validate() error {
+	return q.guard.Validate(ErrGetUncompletedOrdersQueryIsNotConstructed)
+}
+
+// GetUncompletedOrdersQueryResponse represents pending order information.
+// Contains essential data for delivery tracking and courier assignment.
+//
+// Example:
+//
+//	response := GetUncompletedOrdersQueryResponse{
+//	    ID:       kernel.MustNewUUID("123e4567-e89b-12d3-a456-426614174000"),
+//	    Location: kernel.NewLocation(40.7128, -74.0060), // New York
+//	}
+type GetUncompletedOrdersQueryResponse struct {
+	ID       kernel.UUID
+	Location kernel.Location
+}

--- a/internal/core/application/usecases/queries/get_uncompleted_orders_query_handler.go
+++ b/internal/core/application/usecases/queries/get_uncompleted_orders_query_handler.go
@@ -1,0 +1,103 @@
+package queries
+
+import (
+	"context"
+
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GetUncompletedOrdersQueryHandler retrieves orders pending delivery from the database.
+// Filters out completed orders to provide active delivery workload visibility.
+//
+// Example:
+//
+//	handler := NewGetUncompletedOrdersQueryHandler(db)
+//	query := NewGetUncompletedOrdersQuery()
+//
+//	pendingOrders, err := handler.Handle(ctx, query)
+//	if err != nil {
+//	    log.Printf("Failed to get pending orders: %v", err)
+//	    return err
+//	}
+//
+//	if len(pendingOrders) > 0 {
+//	    fmt.Printf("%d orders awaiting delivery\n", len(pendingOrders))
+//	}
+type GetUncompletedOrdersQueryHandler struct {
+	db *gorm.DB
+}
+
+// NewGetUncompletedOrdersQueryHandler creates a handler for pending order queries.
+// Requires a GORM database connection for query execution.
+func NewGetUncompletedOrdersQueryHandler(db *gorm.DB) GetUncompletedOrdersQueryHandler {
+	return GetUncompletedOrdersQueryHandler{db: db}
+}
+
+// Handle executes the query to retrieve all uncompleted orders.
+// Returns orders in "created" or "assigned" status, excluding completed deliveries.
+// Results are sorted by order ID for consistent output.
+func (h GetUncompletedOrdersQueryHandler) Handle(
+	ctx context.Context,
+	query GetUncompletedOrdersQuery,
+) ([]GetUncompletedOrdersQueryResponse, error) {
+	if err := query.Validate(); err != nil {
+		return nil, err
+	}
+
+	orders := make([]GetUncompletedOrdersQueryResponse, 0)
+
+	rows, err := h.db.WithContext(ctx).Raw(`
+		SELECT 
+			id, 
+			location_x, 
+			location_y 
+		FROM orders
+		WHERE status != ?
+		ORDER BY id
+	`, order.Completed).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var orderResp GetUncompletedOrdersQueryResponse
+		var locationX, locationY int8
+		var id uuid.UUID
+
+		err = rows.Scan(
+			&id,
+			&locationX,
+			&locationY,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		orderID, idErr := kernel.UUIDFromBytes(id[:])
+		if idErr != nil {
+			return nil, idErr
+		}
+		orderResp.ID = orderID
+
+		location, locErr := kernel.NewLocation(
+			kernel.Coordinate(locationX),
+			kernel.Coordinate(locationY),
+		)
+		if locErr != nil {
+			return nil, locErr
+		}
+		orderResp.Location = location
+		orders = append(orders, orderResp)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}

--- a/internal/core/application/usecases/queries/get_uncompleted_orders_query_handler_test.go
+++ b/internal/core/application/usecases/queries/get_uncompleted_orders_query_handler_test.go
@@ -1,0 +1,325 @@
+package queries_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"delivery/internal/adapters/out/postgres/courierrepo"
+	"delivery/internal/adapters/out/postgres/orderrepo"
+	"delivery/internal/core/application/usecases/queries"
+	"delivery/internal/core/domain/model/courier"
+	"delivery/internal/core/domain/model/kernel"
+	"delivery/internal/core/domain/model/order"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	gorm_postgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type GetUncompletedOrdersQueryHandlerTestSuite struct {
+	suite.Suite
+	container   *postgres.PostgresContainer
+	db          *gorm.DB
+	handler     queries.GetUncompletedOrdersQueryHandler
+	orderRepo   *orderrepo.GormOrderRepository
+	courierRepo *courierrepo.GormCourierRepository
+	testCourier *courier.Courier
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) SetupSuite() {
+	ctx := context.Background()
+
+	container, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	suite.Require().NoError(err)
+	suite.container = container
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	suite.Require().NoError(err)
+
+	db, err := gorm.Open(gorm_postgres.Open(dsn), &gorm.Config{})
+	suite.Require().NoError(err)
+	suite.db = db
+
+	err = db.AutoMigrate(&orderrepo.OrderDTO{}, &courierrepo.CourierDTO{}, &courierrepo.StoragePlaceDTO{})
+	suite.Require().NoError(err)
+
+	suite.handler = queries.NewGetUncompletedOrdersQueryHandler(db)
+	suite.orderRepo = orderrepo.NewGormOrderRepository(db, &mockAggregateTracker{})
+	suite.courierRepo = courierrepo.NewGormCourierRepository(db, &mockAggregateTracker{})
+
+	// Create a test courier for assigned orders
+	location, err := kernel.NewLocation(5, 5)
+	suite.Require().NoError(err)
+	suite.testCourier, err = courier.NewCourier(kernel.NewUUID(), "Test Courier", 3, location)
+	suite.Require().NoError(err)
+	err = suite.courierRepo.Add(ctx, suite.testCourier)
+	suite.Require().NoError(err)
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TearDownSuite() {
+	if suite.container != nil {
+		err := suite.container.Terminate(context.Background())
+		suite.Require().NoError(err)
+	}
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) SetupTest() {
+	err := suite.db.Exec("TRUNCATE TABLE orders CASCADE").Error
+	suite.Require().NoError(err)
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_EmptyDatabase_ReturnsEmptySlice() {
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.NotNil(result)
+	suite.Empty(result)
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_WithOnlyCompletedOrders_ReturnsEmptySlice() {
+	// Create and complete an order
+	location, _ := kernel.NewLocation(3, 4)
+	order1, _ := order.NewOrder(kernel.NewUUID(), location, 10)
+	err := order1.Assign(suite.testCourier.ID())
+	suite.Require().NoError(err)
+	err = order1.Complete()
+	suite.Require().NoError(err)
+	err = suite.orderRepo.Add(context.Background(), order1)
+	suite.Require().NoError(err)
+
+	// Create and complete another order
+	location2, _ := kernel.NewLocation(7, 8)
+	order2, _ := order.NewOrder(kernel.NewUUID(), location2, 15)
+	err = order2.Assign(suite.testCourier.ID())
+	suite.Require().NoError(err)
+	err = order2.Complete()
+	suite.Require().NoError(err)
+	err = suite.orderRepo.Add(context.Background(), order2)
+	suite.Require().NoError(err)
+
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.NotNil(result)
+	suite.Empty(result)
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_WithMixedStatuses_ReturnsOnlyUncompleted() {
+	// Create orders with different statuses
+	createdOrders := suite.createCreatedOrders()
+	assignedOrders := suite.createAssignedOrders()
+	completedOrders := suite.createCompletedOrders()
+
+	// Save all orders
+	for _, o := range append(append(createdOrders, assignedOrders...), completedOrders...) {
+		err := suite.orderRepo.Add(context.Background(), o)
+		suite.Require().NoError(err)
+	}
+
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.Len(result, 4) // 2 created + 2 assigned
+
+	// Verify all results are uncompleted orders
+	resultIDs := make(map[kernel.UUID]bool)
+	for _, r := range result {
+		resultIDs[r.ID] = true
+	}
+
+	// Check that all created and assigned orders are in results
+	for _, o := range append(createdOrders, assignedOrders...) {
+		suite.True(resultIDs[o.ID()], "Order %s should be in results", o.ID())
+	}
+
+	// Check that no completed orders are in results
+	for _, o := range completedOrders {
+		suite.False(resultIDs[o.ID()], "Completed order %s should not be in results", o.ID())
+	}
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_InvalidQuery_ReturnsError() {
+	invalidQuery := queries.GetUncompletedOrdersQuery{}
+
+	result, err := suite.handler.Handle(context.Background(), invalidQuery)
+
+	suite.Require().Error(err)
+	suite.Nil(result)
+	suite.Contains(err.Error(), "must be created via NewGetUncompletedOrdersQuery constructor")
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_ContextCancellation_ReturnsError() {
+	// Create many orders to ensure context cancellation happens during processing
+	for range 50 {
+		location, _ := kernel.NewRandomLocation()
+		o, _ := order.NewOrder(kernel.NewUUID(), location, 10)
+		err := suite.orderRepo.Add(context.Background(), o)
+		suite.Require().NoError(err)
+	}
+
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := suite.handler.Handle(ctx, query)
+
+	suite.Require().Error(err)
+	suite.Nil(result)
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_VariousLocations_CorrectlyMapsCoordinates() {
+	testCases := []struct {
+		name string
+		x    kernel.Coordinate
+		y    kernel.Coordinate
+	}{
+		{"Order at Origin", 1, 1},
+		{"Order at Max", 10, 10},
+		{"Order at Center", 5, 5},
+		{"Order at Mixed", 3, 8},
+	}
+
+	ordersByLocation := make(map[string]*order.Order)
+	for _, tc := range testCases {
+		location, err := kernel.NewLocation(tc.x, tc.y)
+		suite.Require().NoError(err)
+
+		o, err := order.NewOrder(kernel.NewUUID(), location, 10)
+		suite.Require().NoError(err)
+
+		err = suite.orderRepo.Add(context.Background(), o)
+		suite.Require().NoError(err)
+
+		ordersByLocation[tc.name] = o
+	}
+
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.Len(result, len(testCases))
+
+	// Map results by ID for verification
+	resultMap := make(map[kernel.UUID]queries.GetUncompletedOrdersQueryResponse)
+	for _, r := range result {
+		resultMap[r.ID] = r
+	}
+
+	// Verify each order's location
+	for name, o := range ordersByLocation {
+		result, exists := resultMap[o.ID()]
+		suite.True(exists, "Order %s not found in results", name)
+
+		isEqual, locErr := o.Location().IsEqual(result.Location)
+		suite.Require().NoError(locErr)
+		suite.True(isEqual, "Location mismatch for order %s", name)
+	}
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) TestHandle_OrdersAreSortedByID() {
+	// Create orders with specific IDs to verify sorting
+	orders := make([]*order.Order, 3)
+	locations := []kernel.Location{}
+
+	for i := range 3 {
+		loc, _ := kernel.NewLocation(kernel.Coordinate(i+1), kernel.Coordinate(i+1))
+		locations = append(locations, loc)
+	}
+
+	// Create orders in reverse order to test sorting
+	for i := 2; i >= 0; i-- {
+		o, err := order.NewOrder(kernel.NewUUID(), locations[i], 10)
+		suite.Require().NoError(err)
+		orders[i] = o
+		err = suite.orderRepo.Add(context.Background(), o)
+		suite.Require().NoError(err)
+	}
+
+	query := queries.NewGetUncompletedOrdersQuery()
+
+	result, err := suite.handler.Handle(context.Background(), query)
+
+	suite.Require().NoError(err)
+	suite.Len(result, 3)
+
+	// Results should be sorted by ID
+	for i := range len(result) - 1 {
+		suite.Less(result[i].ID.String(), result[i+1].ID.String(),
+			"Orders should be sorted by ID: %s should come before %s",
+			result[i].ID, result[i+1].ID)
+	}
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) createCreatedOrders() []*order.Order {
+	orders := make([]*order.Order, 0)
+
+	location1, _ := kernel.NewLocation(2, 3)
+	order1, _ := order.NewOrder(kernel.NewUUID(), location1, 5)
+	orders = append(orders, order1)
+
+	location2, _ := kernel.NewLocation(8, 9)
+	order2, _ := order.NewOrder(kernel.NewUUID(), location2, 12)
+	orders = append(orders, order2)
+
+	return orders
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) createAssignedOrders() []*order.Order {
+	orders := make([]*order.Order, 0)
+
+	location1, _ := kernel.NewLocation(4, 5)
+	order1, _ := order.NewOrder(kernel.NewUUID(), location1, 8)
+	_ = order1.Assign(suite.testCourier.ID())
+	orders = append(orders, order1)
+
+	location2, _ := kernel.NewLocation(6, 7)
+	order2, _ := order.NewOrder(kernel.NewUUID(), location2, 15)
+	_ = order2.Assign(suite.testCourier.ID())
+	orders = append(orders, order2)
+
+	return orders
+}
+
+func (suite *GetUncompletedOrdersQueryHandlerTestSuite) createCompletedOrders() []*order.Order {
+	orders := make([]*order.Order, 0)
+
+	location1, _ := kernel.NewLocation(1, 2)
+	order1, _ := order.NewOrder(kernel.NewUUID(), location1, 20)
+	_ = order1.Assign(suite.testCourier.ID())
+	_ = order1.Complete()
+	orders = append(orders, order1)
+
+	location2, _ := kernel.NewLocation(9, 10)
+	order2, _ := order.NewOrder(kernel.NewUUID(), location2, 25)
+	_ = order2.Assign(suite.testCourier.ID())
+	_ = order2.Complete()
+	orders = append(orders, order2)
+
+	return orders
+}
+
+func TestGetUncompletedOrdersQueryHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(GetUncompletedOrdersQueryHandlerTestSuite))
+}

--- a/internal/core/application/usecases/queries/get_uncompleted_orders_query_test.go
+++ b/internal/core/application/usecases/queries/get_uncompleted_orders_query_test.go
@@ -1,0 +1,23 @@
+package queries_test
+
+import (
+	"testing"
+
+	"delivery/internal/core/application/usecases/queries"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGetUncompletedOrdersQuery_Valid(t *testing.T) {
+	query := queries.NewGetUncompletedOrdersQuery()
+	err := query.Validate()
+	require.NoError(t, err)
+}
+
+func TestGetUncompletedOrdersQuery_NotConstructedViaConstructor(t *testing.T) {
+	query := queries.GetUncompletedOrdersQuery{}
+	err := query.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, queries.ErrGetUncompletedOrdersQueryIsNotConstructed)
+}


### PR DESCRIPTION
  - Add command handlers for courier and order operations (create, add storage, assign, move)
  - Implement composition root with dependency injection for all handlers
  - Add database auto-migration on startup for courier and order entities
  - Make UoW rollback safe for defer statements (returns nil for inactive transactions)
  - Disable ireturn linter to allow returning interfaces from factories